### PR TITLE
v1.0.5

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Fragments/Terminals/TERM_WSFW_Options_Menu_Functionality.psc
+++ b/Scripts/Source/User/WorkshopFramework/Fragments/Terminals/TERM_WSFW_Options_Menu_Functionality.psc
@@ -249,6 +249,22 @@ Setting_AllowSettlementsToLeavePlayerControl.SetValue(1.0)
 EndFunction
 ;END FRAGMENT
 
+;BEGIN FRAGMENT Fragment_Terminal_32
+Function Fragment_Terminal_32(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_ShelterMechanic.SetValue(0.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_33
+Function Fragment_Terminal_33(ObjectReference akTerminalRef)
+;BEGIN CODE
+Setting_ShelterMechanic.SetValue(1.0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
 ;END FRAGMENT CODE - Do not edit anything between this and the begin comment
 
 GlobalVariable Property Setting_AdjustMaxNPCsByCharisma Auto Const
@@ -262,3 +278,5 @@ GlobalVariable Property Setting_RobotsCountTowardsMaxPopulation Auto Const
 GlobalVariable Property Setting_RobotHappinessLevel Auto Const
 
 GlobalVariable Property Setting_AllowSettlementsToLeavePlayerControl Auto Const
+
+GlobalVariable Property Setting_ShelterMechanic Auto Const

--- a/Scripts/Source/User/WorkshopFramework/HUDFrameworkManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/HUDFrameworkManager.psc
@@ -117,7 +117,7 @@ EndFunction
 
 
 Bool Function RegisterWidget(ScriptObject akHandler, String asWidgetName, Float afPositionX, Float afPositionY, Bool abLoadNow = true, Bool abAutoLoad = true)
-	if( ! IsHUDFrameworkInstalled)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
 		return false
 	endif
 	
@@ -157,6 +157,10 @@ EndFunction
 
 
 Function UnregisterWidget(String asWidgetName)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	int index = RegisteredWidgets.Find(asWidgetName)
 	
 	if(index > -1)
@@ -171,6 +175,10 @@ EndFunction
 
 
 Bool Function IsWidgetLoaded(String asWidgetName)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return false
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Widget " + asWidgetName + " it is not registered yet.")
 		return false
@@ -184,6 +192,10 @@ EndFunction
 
 
 Function LoadWidget(String asWidgetName)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to load widget " + asWidgetName + ", it is not registered yet.")
 		return
@@ -197,6 +209,10 @@ EndFunction
 
 
 Function UnloadWidget(String asWidgetName)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to unload widget " + asWidgetName + ", it is not registered yet.")
 		return
@@ -210,6 +226,10 @@ EndFunction
 
 
 Function SetWidgetPosition(String asWidgetName, Float afX, Float afY, Bool abTemporary = false)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -226,6 +246,10 @@ EndFunction
 
 
 Function ModWidgetPosition(String asWidgetName, Float afDeltaX = 0.0, Float afDeltaY = 0.0, Bool abTemporary = False)	
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -242,6 +266,10 @@ EndFunction
 
 
 Float[] Function GetWidgetPosition(String asWidgetName)	
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return None
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return None
@@ -254,6 +282,10 @@ EndFunction
 
 
 Function SetWidgetScale(String asWidgetName, Float afScaleX, Float afScaleY, Bool abTemporary = false)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -269,7 +301,11 @@ Function SetWidgetScale(String asWidgetName, Float afScaleX, Float afScaleY, Boo
 EndFunction
 
 
-Function ModWidgetScale(String asWidgetName, Float afScaleX = 0.0, Float afScaleY = 0.0, Bool abTemporary = False)	
+Function ModWidgetScale(String asWidgetName, Float afScaleX = 0.0, Float afScaleY = 0.0, Bool abTemporary = False)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -297,6 +333,10 @@ EndFunction
 
 
 Function SetWidgetOpacity(String asWidgetName, Float afOpacity = 1.0, Bool abTemporary = False)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -312,6 +352,10 @@ EndFunction
 
 
 Float Function GetWidgetOpacity(String asWidgetName)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return -1.0
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return -1.0
@@ -328,6 +372,10 @@ EndFunction
 Function SendMessage(string asWidgetName, int aiCommand, float arg1 = 0.0, float arg2 = 0.0, \
     float arg3 = 0.0, float arg4 = 0.0, float arg5 = 0.0, float arg6 = 0.0)
 
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -351,6 +399,10 @@ Function SendCustomMessage(Message akMessageToSend, float arg1 = 0.0, float arg2
     float arg3 = 0.0, float arg4 = 0.0, float arg5 = 0.0, float arg6 = 0.0, float arg7 = 0.0, \
     float arg8 = 0.0, float arg9 = 0.0)
 		
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	Var[] Args = new Var[11]
 	Args[0] = akMessageToSend
 	Args[1] = arg1
@@ -370,6 +422,10 @@ EndFunction
 Function SendMessageString(string asWidgetName, string asCommand, string asBody, \
     bool abReplaceExisting = True, bool abDeferSend = False)
 	
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	if(RegisteredWidgets.Find(asWidgetName) < 0)
 		ModTrace("[WSFW] Unable to send command to HUDFramework. Widget " + asWidgetName + " is not registered yet.")
 		return
@@ -387,6 +443,10 @@ EndFunction
 
 
 Function Eval(string asExpression)
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	Var[] Args = new Var[1]
 	Args[0] = asExpression
 	
@@ -423,6 +483,10 @@ EndFunction
 
 
 Function ShowHUDWidgetsInWorkshopMode()
+	if( ! IsHUDFrameworkInstalled) ; 1.0.5 - Needs HF to continue
+		return 
+	endif
+	
 	Var[] Args = new Var[5]
 	Args[0] = "HUDFramework"
 	Args[1] = "SwitchToPA"

--- a/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/PreventDroppingOnGround.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/PreventDroppingOnGround.psc
@@ -1,0 +1,31 @@
+; ---------------------------------------------
+; WorkshopFramework:Library:ObjectRefs:PreventDroppingOnGround.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below.
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDIT
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:Library:ObjectRefs:PreventDroppingOnGround extends ObjectReference
+{ Put this on items that you don't want the player to drop on the ground }
+
+Bool Property bReturnToInventory = false Auto Const
+{ If true, this will be put back in the player's inventory - otherwise it will just be destroyed }
+
+Event OnContainerChanged(ObjectReference akNewContainer, ObjectReference akOldContainer)
+	ObjectReference PlayerRef = Game.GetPlayer()
+	
+	if(akOldContainer == PlayerRef && ! akNewContainer)
+		if(bReturnToInventory)
+			PlayerRef.AddItem(Self)
+		else
+			Disable(false)
+			Delete()
+		endif
+	endif
+EndEvent

--- a/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/Thread.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/Thread.psc
@@ -37,7 +37,9 @@ String Property sCustomCallbackID = "" Auto Hidden
 
 Event OnTimer(Int aiTimerID)
 	if(aiTimerID == SelfDestructTimerID)
-		SelfDestruct()
+		if(bAutoDestroy) ; 1.0.5 - without this, we can't have the threads turn off their own self destruct to delay for events
+			SelfDestruct()
+		endif
 	endif
 EndEvent
 

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
@@ -1,0 +1,188 @@
+; ---------------------------------------------
+; WorkshopFramework:ObjectRefs:InvisibleWorkshopObject.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:ObjectRefs:InvisibleWorkshopObject extends WorkshopObjectScript
+{ Control object that is visible and interactable in Workshop Mode only. Meant to be used to spawn an otherwise invisible object, such as an animation marker. }
+
+; ---------------------------------------------
+; Consts
+; ---------------------------------------------
+
+String sPlugin_WSFW = "WorkshopFramework.esm"
+String sPlugin_Fallout4 = "Fallout4.esm"
+
+int iFormID_InvisibleWorkshopObjectKeyword = 0x00006B5A
+int iFormID_WorkshopItemKeyword = 0x00054BA6
+int iFormID_WorkshopStackedItemParentKeyword = 0X001C5EDD
+
+; ---------------------------------------------
+; Editor Properties 
+; ---------------------------------------------
+
+Group InvisibleSettings
+	Form Property ControlledObjectForm Auto Const Mandatory
+	{ One of these will be created and attached. }
+	Bool Property bReverse = false Auto Const
+	{ If set to true, the ControlledObjectForm will be hidden in Workshop Mode, instead of this. }
+EndGroup
+
+Group InvisibleSettings_Advanced Collapsed
+	Bool Property bLinkControlledObjectToWorkshop = true Auto Const
+	{ Set to false to prevent the controlled object from being linked to the workshop. }
+	Bool Property bAttachObjects = true Auto Const
+	{ If set to false, the objects will not follow each other, meaning the player will be able to move them independent of each other. }
+	Bool Property bReverseFlipsStacking = false Auto Const
+	{ If bReverse = true, and bAttachObjects then the Controlled Object will become the main moveable object that is meant to be picked up in workshop mode. }	
+EndGroup
+
+
+; ---------------------------------------------
+; Vars
+; ---------------------------------------------
+
+Keyword InvisibleWorkshopObjectKeyword
+Keyword WorkshopItemKeyword
+Keyword WorkshopStackedItemParentKeyword
+Bool bWorkshopMode = true
+ObjectReference Property kControlledRef Auto Hidden
+
+
+; ---------------------------------------------
+; Events
+; ---------------------------------------------
+
+Event OnInit()
+	UpdateVars()
+	
+	; Add the keyword so the manager can pick us up
+	Self.AddKeyword(InvisibleWorkshopObjectKeyword)
+	
+	UpdateDisplay()
+EndEvent
+
+
+Event OnWorkshopObjectDestroyed(ObjectReference akWorkshopRef)
+	Cleanup()
+EndEvent
+
+Event OnWorkshopObjectMoved(ObjectReference akWorkshopRef)
+	UpdateDisplay()
+EndEvent
+
+; ---------------------------------------------
+; Functions
+; ---------------------------------------------
+
+Function Toggle(Bool abWorkshopMode)
+	if( ! IsBoundGameObjectAvailable())
+		return
+	endif
+		
+	bWorkshopMode = abWorkshopMode
+	
+	UpdateDisplay()
+EndFunction
+
+
+Function UpdateDisplay()
+	if(IsDeleted())
+		Cleanup()
+		return
+	endif	
+	
+	if( ! kControlledRef)
+		kControlledRef = PlaceAtMe(ControlledObjectForm, abDeleteWhenAble = false)
+		
+		if(bLinkControlledObjectToWorkshop)
+			kControlledRef.SetLinkedRef(GetLinkedRef(WorkshopItemKeyword), WorkshopItemKeyword)
+		endif
+	else
+		if(bReverse && bReverseFlipsStacking)
+			Self.MoveTo(kControlledRef)
+		else
+			kControlledRef.MoveTo(Self)
+		endif
+	endif
+	
+	; Set up the controlled ref so it follows this one in WS mode - relinking it every time in case it was moved independently which would cause the game to break the link
+	if(bAttachObjects)
+		if(bReverse && bReverseFlipsStacking)
+			Self.SetLinkedRef(kControlledRef, WorkshopStackedItemParentKeyword)
+		else
+			kControlledRef.SetLinkedRef(Self, WorkshopStackedItemParentKeyword)
+		endif
+	endif
+	
+	if(bWorkshopMode)
+		if(bReverse)
+			kControlledRef.Enable(false)
+			
+			if(Self.IsDisabled())
+				; Likely disabled due to not having a COBJ record and therefore was destroyed due to the WorkshopStackedItemParentKeyword link
+				Self.Enable(false)
+			endif
+		else
+			Self.Enable(false)
+			
+			if(kControlledRef.IsDisabled())
+				; Likely disabled due to not having a COBJ record and therefore was destroyed due to the WorkshopStackedItemParentKeyword link
+				kControlledRef.Enable(false)
+			endif
+		endif
+	else
+		if(bReverse)
+			kControlledRef.Disable(false)
+			
+			if(Self.IsDisabled())
+				; Likely disabled due to not having a COBJ record and therefore was destroyed due to the WorkshopStackedItemParentKeyword link
+				Self.Enable(false)
+			endif
+		else
+			Self.Disable(false)
+			
+			if(kControlledRef.IsDisabled())
+				; Likely disabled due to not having a COBJ record and therefore was destroyed due to the WorkshopStackedItemParentKeyword link
+				kControlledRef.Enable(false)
+			endif
+		endif
+	endif
+EndFunction
+
+
+Function UpdateVars()
+	if( ! InvisibleWorkshopObjectKeyword)
+		InvisibleWorkshopObjectKeyword = Game.GetFormFromFile(iFormID_InvisibleWorkshopObjectKeyword, sPlugin_WSFW) as Keyword
+	endif	
+	
+	if( ! WorkshopItemKeyword)
+		WorkshopItemKeyword = Game.GetFormFromFile(iFormID_WorkshopItemKeyword, sPlugin_Fallout4) as Keyword
+	endif
+	
+	if( ! WorkshopStackedItemParentKeyword)
+		WorkshopStackedItemParentKeyword = Game.GetFormFromFile(iFormID_WorkshopStackedItemParentKeyword, sPlugin_Fallout4) as Keyword
+	endif	
+EndFunction
+
+
+Function Delete()
+	Cleanup()
+EndFunction
+
+Function Cleanup()
+	Self.SetLinkedRef(None, WorkshopStackedItemParentKeyword)
+	kControlledRef.SetLinkedRef(None, WorkshopStackedItemParentKeyword)
+	kControlledRef.SetLinkedRef(None, WorkshopItemKeyword)
+	kControlledRef.Disable(false)
+	kControlledRef.Delete()
+	kControlledRef = None
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_ToggleInvisibleWorkshopObjects.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_ToggleInvisibleWorkshopObjects.psc
@@ -1,0 +1,57 @@
+; ---------------------------------------------
+; WorkshopFramework:ObjectRefs:Thread_ToggleInvisibleWorkshopObjects.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:ObjectRefs:Thread_ToggleInvisibleWorkshopObjects extends WorkshopFramework:Library:ObjectRefs:Thread
+
+; -
+; Consts
+; -
+
+
+; - 
+; Editor Properties
+; -
+
+
+; -
+; Properties
+; -
+
+Bool Property bInWorkshopMode Auto Hidden
+ObjectReference[] Property kObjectRefs Auto Hidden
+
+; -
+; Events
+; -
+
+; - 
+; Functions 
+; -
+
+	
+Function ReleaseObjectReferences()
+	kObjectRefs = None
+EndFunction
+
+
+Function RunCode()
+	int i = 0
+	while(i < kObjectRefs.Length)
+		WorkshopFramework:ObjectRefs:InvisibleWorkshopObject asInvis = kObjectRefs[i] as WorkshopFramework:ObjectRefs:InvisibleWorkshopObject
+		if(asInvis)
+			asInvis.Toggle(bInWorkshopMode)
+		endif
+		
+		i += 1
+	endWhile
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/PlaceObjectManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/PlaceObjectManager.psc
@@ -21,19 +21,24 @@ import WorkshopFramework:Library:ThirdParty:Cobb:CobbLibraryRotations
 CustomEvent ObjectBatchCreated
 CustomEvent ObjectRemoved
 
-Struct ObjectWatch
+; 1.0.5 - Creating new event
+CustomEvent SimpleObjectBatchCreated ; Simplied version of batch system that doesn't require testing each item for an AV
+
+
+; 1.0.5 - Simplified ObjectWatch
+Struct ObjectWatchSimple
 	int iAwaitingObjectCount = 0
-	ActorValue WithAV
-	Float WithAVValue
+	int iBatchID = 0
 	int iSeenObjectCount = 0
+	int iBatchIndex = 0
 EndStruct
 
 ; ---------------------------------------------
 ; Consts
 ; ---------------------------------------------
 
-String sThreadID_ObjectCreated = "ObjectCreated"
 String sThreadID_ObjectRemoved = "ObjectRemoved"
+String sThreadID_ObjectPlaced = "ObjectPlaced" ; 1.0.5 - switching over to new event so we don't break earlier saves that might be relying on ObjectCreated
 Int MAXBATCHQUEUEID = 1000000
 
 ; ---------------------------------------------
@@ -49,6 +54,8 @@ Group Aliases
 	{ Temporary holder to track created objects returned from thread manager }
 	RefCollectionAlias Property SentObjects Auto Const Mandatory
 	{ Temporary holder to track which objects have been sent out in an event }
+	RefCollectionAlias[] Property PlacedObjects Auto Const Mandatory
+	{ 1.0.5 - Streamlining the threaded object creation. We'll now have a RefCollection for each of the Batches and just put the items in as opposed to having to test each item for an AV. }
 EndGroup
 
 Group Assets
@@ -65,18 +72,20 @@ EndGroup
 ; Properties
 ; ---------------------------------------------
 
-Int iLastQueuedBatchIndex = -1
-Int Property NextQueuedBatchIndex	
+; 1.0.5 - Need a second index tracker as the previous version is being made obsolete
+Int iLastQueuedSimpleBatchIndex = -1
+Int Property NextQueuedSimpleBatchIndex	
 	Int Function Get()
-		iLastQueuedBatchIndex += 1
+		iLastQueuedSimpleBatchIndex += 1
 		
-		if(iLastQueuedBatchIndex > 127)
-			iLastQueuedBatchIndex = 0
+		if(iLastQueuedSimpleBatchIndex > 127)
+			iLastQueuedSimpleBatchIndex = 0
 		endif
 		
-		return iLastQueuedBatchIndex
+		return iLastQueuedSimpleBatchIndex
 	EndFunction
 EndProperty
+
 
 Int iLastQueuedBatchID = -1
 Int Property NextQueuedBatchID	
@@ -93,7 +102,7 @@ EndProperty
 ; Vars
 ; ---------------------------------------------
 
-ObjectWatch[] QueuedBatches
+ObjectWatchSimple[] QueuedSimpleBatches ; 1.0.5
 
 ; ---------------------------------------------
 ; Events 
@@ -102,21 +111,35 @@ ObjectWatch[] QueuedBatches
 Event WorkshopFramework:Library:ThreadRunner.OnThreadCompleted(WorkshopFramework:Library:ThreadRunner akThreadRunner, Var[] akargs)
 	; akargs[0] = sCustomCallCallbackID, akargs[1] = iCallbackID, akargs[2] = ThreadRef
 	String sCustomCallCallbackID = akargs[0] as String
+	
+	;ModTrace("Received event with callback ID: " + sCustomCallCallbackID)
 	if(sCustomCallCallbackID == sThreadID_ObjectCreated)
 		WorkshopFramework:ObjectRefs:Thread_PlaceObject kThreadRef = akargs[2] as WorkshopFramework:ObjectRefs:Thread_PlaceObject
 		if(kThreadRef)
 			ObjectReference kCreatedRef = kThreadRef.kResult
 			
-			if(kCreatedRef)
+			if(kCreatedRef)				
 				CreatedObjects.AddRef(kCreatedRef)
-				
-				ModTrace("[WSFW] PlaceObjectManager - CreatedRef " + kCreatedRef + "returned from thread, updating monitors.")
-				
+				;ModTrace("[WSFW] PlaceObjectManager - CreatedRef " + kCreatedRef + "returned from thread, updating batch monitors.")
 				UpdateMonitors(kCreatedRef)
-			endif
+ 			endif
 			
 			; Clean up thread now that we have the result
 			kThreadRef.SelfDestruct()
+		endif
+	elseif(sCustomCallCallbackID == sThreadID_ObjectPlaced)
+		; 1.0.5 - Switching to a new callback event and method
+		WorkshopFramework:ObjectRefs:Thread_PlaceObject kThreadRef = akargs[2] as WorkshopFramework:ObjectRefs:Thread_PlaceObject
+		if(kThreadRef)
+			ObjectReference kCreatedRef = kThreadRef.kResult
+			int iBatchID = kThreadRef.iBatchID
+			
+			ModTrace("[WSFW] PlaceObjectManager - CreatedRef " + kCreatedRef + " returned from thread, updating simple monitor for batch " + iBatchID)
+			if(kCreatedRef && iBatchID >= 0)
+				int iBatchIndex = GetSimpleBatchIndex(iBatchID)
+				PlacedObjects[iBatchIndex].AddRef(kCreatedRef)		
+				UpdateSimpleBatchMonitor(iBatchIndex)						
+			endif
 		endif
 	elseif(sCustomCallCallbackID == sThreadID_ObjectRemoved)
 		WorkshopFramework:ObjectRefs:Thread_ScrapObject kThreadRef = akargs[2] as WorkshopFramework:ObjectRefs:Thread_ScrapObject
@@ -156,6 +179,320 @@ EndFunction
 ; ---------------------------------------------
 ; Functions
 ; ---------------------------------------------
+
+; 1.0.5 - Simplifying this function so it doesn't require checking each item for an AV
+Int Function CreateBatchObjectsV2(WorldObject[] PlaceMe, WorkshopScript akWorkshopRef = None, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true)
+	; Setup a monitor so we can fire off an event when these are all created
+	Int iBatchID = NextQueuedBatchID
+	
+	if(abCallbackEventNeeded)
+		ObjectWatchSimple NewBatch = new ObjectWatchSimple
+		NewBatch.iAwaitingObjectCount = PlaceMe.Length
+		NewBatch.iSeenObjectCount = 0
+		NewBatch.iBatchID = iBatchID
+		
+		ModTrace("[WSFW] PlaceObjectManager: CreateBatchObjectsV2 setting up simple batch monitor " + NewBatch + ".")
+		
+		MonitorSimpleBatch(NewBatch)
+	endif
+	
+	; Send all creation requests to the thread manager
+	Float[] fPosition = new Float[3]
+	Float[] fAngle = new Float[3]
+		
+	if(akPositionRelativeTo)		
+		; Calculate this here so we're not doing it over and over inside the loop
+		fPosition[0] = akPositionRelativeTo.X
+		fPosition[1] = akPositionRelativeTo.Y
+		fPosition[2] = akPositionRelativeTo.Z
+		fAngle[0] = akPositionRelativeTo.GetAngleX()
+		fAngle[1] = akPositionRelativeTo.GetAngleY()
+		fAngle[2] = akPositionRelativeTo.GetAngleZ()
+	endif
+			
+	int i = 0
+	int index = 0
+	while(i < PlaceMe.Length)
+		; Create new version of WorldObject
+		WorldObject newObject = PlaceMe[index]
+		
+		if(akPositionRelativeTo)
+			; Calculate new coords
+			Float[] fPosOffset = new Float[3]
+			Float[] fAngleOffset = new Float[3]
+			Float[] fNew3dData = new Float[6]
+			
+			fPosOffset[0] = newObject.fPosX
+			fPosOffset[1] = newObject.fPosY
+			fPosOffset[2] = newObject.fPosZ
+			fAngleOffset[0] = newObject.fAngleX
+			fAngleOffset[1] = newObject.fAngleY
+			fAngleOffset[2] = newObject.fAngleZ
+			
+			fNew3dData = GetCoordinatesRelativeToBase(fPosition, fAngle, fPosOffset, fAngleOffset)
+			
+			newObject.fPosX = fNew3dData[0]
+			newObject.fPosY = fNew3dData[1]
+			newObject.fPosZ = fNew3dData[2]
+			newObject.fAngleX = fNew3dData[3]
+			newObject.fAngleY = fNew3dData[4]
+			newObject.fAngleZ = fNew3dData[5]
+		endif
+		
+		CreateObject_Private(newObject, akWorkshopRef, None, -1, None, abStartEnabled, abCallbackEventNeeded, sThreadID_ObjectPlaced, iBatchID)
+		
+		index += 1
+		if(index >= PlaceMe.Length)
+			index = 0
+		endif
+		i += 1
+	endWhile
+	
+	return iBatchID
+EndFunction
+
+
+Function MonitorSimpleBatch(ObjectWatchSimple aBatch)
+	if( ! QueuedSimpleBatches)
+		QueuedSimpleBatches = new ObjectWatchSimple[0]
+	endif
+	
+	int IncrementIndex = NextQueuedSimpleBatchIndex
+	
+	aBatch.iBatchIndex = IncrementIndex
+	
+	if(QueuedSimpleBatches.Length < 128)
+		QueuedSimpleBatches.Add(aBatch)
+	else
+		QueuedSimpleBatches[IncrementIndex] = aBatch
+	endif
+	
+	Debug.Trace("Stored simple batch monitor at index " + IncrementIndex + ": " + QueuedSimpleBatches)
+EndFunction
+
+
+Int Function GetSimpleBatchIndex(Int aiBatchID)
+	int i = 0
+	while(i < QueuedSimpleBatches.Length)
+		if(QueuedSimpleBatches[i].iBatchID == aiBatchID)
+			return QueuedSimpleBatches[i].iBatchIndex
+		endif
+		
+		i += 1
+	endWhile
+	
+	return -1
+EndFunction
+
+
+Function UpdateSimpleBatchMonitor(Int aiBatchIndex, Int aiAdditionalSeenObjects = 1)
+	if(aiBatchIndex >= 0)
+		QueuedSimpleBatches[aiBatchIndex].iSeenObjectCount += aiAdditionalSeenObjects
+		
+		if(QueuedSimpleBatches[aiBatchIndex].iSeenObjectCount >= QueuedSimpleBatches[aiBatchIndex].iAwaitingObjectCount)
+			; Send all objects
+			SimpleFetchMyObjects(aiBatchIndex)
+			
+			; Clear out this entry
+			QueuedSimpleBatches[aiBatchIndex] = new ObjectWatchSimple
+		endif
+	endif
+EndFunction
+
+
+Function SimpleFetchMyObjects(Int aiBatchIndex)
+	; Send all objects in the corresponding alias, then clear the alias
+	int i = 0
+	int iBatchID = QueuedSimpleBatches[aiBatchIndex].iBatchID
+	int iTotal = PlacedObjects[aiBatchIndex].GetCount()
+	ObjectReference[] kSendBatch = new ObjectReference[0]
+	while(i < iTotal)
+		ObjectReference thisObject = PlacedObjects[aiBatchIndex].GetAt(i)
+		if(kSendBatch.Length == 126 && iTotal > i + 1)
+			SendSimpleBatchEvent(kSendBatch, iBatchID, true)
+						
+			kSendBatch = new ObjectReference[0]
+		endif
+		
+		kSendBatch.Add(thisObject)	
+		
+		i += 1
+	endWhile
+	
+	if(kSendBatch.Length > 0)
+		SendSimpleBatchEvent(kSendBatch, iBatchID, false)
+		
+		SentObjects.AddArray(kSendBatch)
+	endif
+	
+	PlacedObjects[aiBatchIndex].RemoveAll()
+EndFunction
+
+
+Function SendSimpleBatchEvent(ObjectReference[] akSendRefs, Int aiBatchID, Bool abMoreEventsComing)
+	Var[] kArgs = new Var[0]
+	
+	kArgs.Add(aiBatchID)
+	kArgs.Add(abMoreEventsComing)
+	
+	int i = 0 
+	while(i < akSendRefs.Length)
+		kArgs.Add(akSendRefs[i])
+		
+		i += 1
+	endWhile
+	
+	SendCustomEvent("SimpleObjectBatchCreated", kArgs)
+EndFunction
+
+
+; 1.0.5 - Added Private version so we could add additional args
+Int Function CreateObject(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true)
+	CreateObject_Private(aPlaceMe, akWorkshopRef, aSetAV, aiFormlistIndex, akPositionRelativeTo, abStartEnabled, abCallbackEventNeeded, sThreadID_ObjectCreated, aiBatchID = -1)
+EndFunction
+
+Int Function CreateObject_Private(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true, String asCustomCallBackID = "", Int aiBatchID = -1)
+	; Send creation request to the thread manager
+	Form FormToPlace = GetWorldObjectForm(aPlaceMe, aiFormlistIndex)
+		
+	if(FormToPlace)
+		String sCustomCallbackID = asCustomCallBackID
+		if( ! abCallbackEventNeeded)
+			sCustomCallbackID = ""
+		else
+			ModTrace("[WSFW] PlaceObjectManager: Creating CreateObject thread - requesting callback event.")
+		endif
+		
+		WorkshopFramework:ObjectRefs:Thread_PlaceObject kThread = ThreadManager.CreateThread(PlaceObjectThread) as WorkshopFramework:ObjectRefs:Thread_PlaceObject
+		
+		if(kThread)
+			if(aSetAV)
+				kThread.AddTagAVSet(GetActorValueSetForm(aSetAV), aSetAV.fValue)
+			endif
+			
+			kThread.bFadeIn = false ; 1.0.5 - Using new fade bool to ensure items pop in quickly
+			kThread.bStartEnabled = abStartEnabled
+			kThread.bForceStatic = aPlaceMe.bForceStatic
+			kThread.kSpawnAt = PlayerRef
+			kThread.SpawnMe = FormToPlace
+			kThread.fPosX = aPlaceMe.fPosX
+			kThread.fPosY = aPlaceMe.fPosY
+			kThread.fPosZ = aPlaceMe.fPosZ
+			kThread.fAngleX = aPlaceMe.fAngleX
+			kThread.fAngleY = aPlaceMe.fAngleY
+			kThread.fAngleZ = aPlaceMe.fAngleZ
+			kThread.fScale = aPlaceMe.fScale
+			kThread.kWorkshopRef = akWorkshopRef
+			
+			; 1.0.5
+			kThread.iBatchID = aiBatchID
+			
+			int iCallBackID = ThreadManager.QueueThread(kThread, sCustomCallbackID)
+			
+			return iCallBackID
+		endif
+	endif
+		
+	return -1
+EndFunction
+
+
+ObjectReference Function CreateObjectImmediately(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true)
+	; Send creation request to the thread manager
+	Form FormToPlace = GetWorldObjectForm(aPlaceMe, aiFormlistIndex)
+		
+	if(FormToPlace)
+		WorkshopFramework:ObjectRefs:Thread_PlaceObject kThread = ThreadManager.CreateThread(PlaceObjectThread) as WorkshopFramework:ObjectRefs:Thread_PlaceObject
+		
+		if(kThread)
+			if(aSetAV)
+				kThread.AddTagAVSet(GetActorValueSetForm(aSetAV), aSetAV.fValue)
+			endif
+			
+			kThread.bFadeIn = false ; 1.0.5 - Using new fade bool to ensure items pop in quickly
+			kThread.bStartEnabled = abStartEnabled
+			kThread.bForceStatic = aPlaceMe.bForceStatic
+			kThread.kSpawnAt = PlayerRef
+			kThread.SpawnMe = FormToPlace
+			kThread.fPosX = aPlaceMe.fPosX
+			kThread.fPosY = aPlaceMe.fPosY
+			kThread.fPosZ = aPlaceMe.fPosZ
+			kThread.fAngleX = aPlaceMe.fAngleX
+			kThread.fAngleY = aPlaceMe.fAngleY
+			kThread.fAngleZ = aPlaceMe.fAngleZ
+			kThread.fScale = aPlaceMe.fScale
+			kThread.kWorkshopRef = akWorkshopRef
+			
+			kThread.RunCode()
+			
+			ObjectReference kCreatedRef = kThread.kResult
+			
+			if( ! kThread.bAwaitingOnLoadEvent)
+				kThread.SelfDestruct()
+			endif
+			
+			return kCreatedRef
+		endif
+	endif
+		
+	return None
+EndFunction
+
+
+Int Function ScrapObject(ObjectReference akScrapMe, Bool abCallbackEventNeeded = true)
+	; Send creation request to the thread manager
+	String sCustomCallbackID = sThreadID_ObjectRemoved
+	if( ! abCallbackEventNeeded)
+		sCustomCallbackID = ""
+	else
+		ModTrace("[WSFW] PlaceObjectManager: Creating ScrapObject thread - requesting callback event.")
+	endif
+		
+	WorkshopFramework:ObjectRefs:Thread_ScrapObject kThread = ThreadManager.CreateThread(ScrapObjectThread) as WorkshopFramework:ObjectRefs:Thread_ScrapObject
+	
+	if(kThread)
+		kThread.kScrapMe = akScrapMe
+					
+		int iCallBackID = ThreadManager.QueueThread(kThread, sCustomCallbackID)
+		
+		return iCallBackID
+	endif	
+		
+	return -1
+EndFunction
+
+
+; ==================================================================================
+; ==================================================================================
+; 1.0.5 - Everything below here is obsolete, maintaining for backwards compatibility
+; ==================================================================================
+; ==================================================================================
+
+String sThreadID_ObjectCreated = "ObjectCreated"
+
+Struct ObjectWatch
+	int iAwaitingObjectCount = 0
+	ActorValue WithAV
+	Float WithAVValue
+	int iSeenObjectCount = 0
+EndStruct
+
+
+ObjectWatch[] QueuedBatches
+
+
+Int iLastQueuedBatchIndex = -1
+Int Property NextQueuedBatchIndex	
+	Int Function Get()
+		iLastQueuedBatchIndex += 1
+		
+		if(iLastQueuedBatchIndex > 127)
+			iLastQueuedBatchIndex = 0
+		endif
+		
+		return iLastQueuedBatchIndex
+	EndFunction
+EndProperty
 
 Int Function CreateBatchObjects(WorldObject[] PlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true)
 	; Setup a monitor so we can fire off an event when these are all created
@@ -228,7 +565,8 @@ Int Function CreateBatchObjects(WorldObject[] PlaceMe, WorkshopScript akWorkshop
 			newObject.fAngleZ = fNew3dData[5]
 		endif
 		
-		CreateObject(newObject, akWorkshopRef, aSetAV, -1, None, abStartEnabled, abCallbackEventNeeded)
+		; 1.0.5 - Updating to new version that handles specifying a batch ID and callback string
+		CreateObject_Private(newObject, akWorkshopRef, aSetAV, -1, None, abStartEnabled, abCallbackEventNeeded, sThreadID_ObjectCreated, iBatchID)
 		
 		index += 1
 		if(index >= PlaceMe.Length)
@@ -240,111 +578,21 @@ Int Function CreateBatchObjects(WorldObject[] PlaceMe, WorkshopScript akWorkshop
 	return iBatchID
 EndFunction
 
-
-Int Function CreateObject(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true)
-	; Send creation request to the thread manager
-	Form FormToPlace = GetWorldObjectForm(aPlaceMe, aiFormlistIndex)
-		
-	if(FormToPlace)
-		String sCustomCallbackID = sThreadID_ObjectCreated
-		if( ! abCallbackEventNeeded)
-			sCustomCallbackID = ""
-		else
-			ModTrace("[WSFW] PlaceObjectManager: Creating CreateObject thread - requesting callback event.")
-		endif
-		
-		WorkshopFramework:ObjectRefs:Thread_PlaceObject kThread = ThreadManager.CreateThread(PlaceObjectThread) as WorkshopFramework:ObjectRefs:Thread_PlaceObject
-		
-		if(kThread)
-			if(aSetAV)
-				kThread.AddTagAVSet(GetActorValueSetForm(aSetAV), aSetAV.fValue)
-			endif
-			
-			kThread.bStartEnabled = abStartEnabled
-			kThread.bForceStatic = aPlaceMe.bForceStatic
-			kThread.kSpawnAt = PlayerRef
-			kThread.SpawnMe = FormToPlace
-			kThread.fPosX = aPlaceMe.fPosX
-			kThread.fPosY = aPlaceMe.fPosY
-			kThread.fPosZ = aPlaceMe.fPosZ
-			kThread.fAngleX = aPlaceMe.fAngleX
-			kThread.fAngleY = aPlaceMe.fAngleY
-			kThread.fAngleZ = aPlaceMe.fAngleZ
-			kThread.fScale = aPlaceMe.fScale
-			kThread.kWorkshopRef = akWorkshopRef
-			
-			int iCallBackID = ThreadManager.QueueThread(kThread, sCustomCallbackID)
-			
-			return iCallBackID
-		endif
-	endif
-		
-	return -1
-EndFunction
-
-
-ObjectReference Function CreateObjectImmediately(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true)
-	; Send creation request to the thread manager
-	Form FormToPlace = GetWorldObjectForm(aPlaceMe, aiFormlistIndex)
-		
-	if(FormToPlace)
-		WorkshopFramework:ObjectRefs:Thread_PlaceObject kThread = ThreadManager.CreateThread(PlaceObjectThread) as WorkshopFramework:ObjectRefs:Thread_PlaceObject
-		
-		if(kThread)
-			if(aSetAV)
-				kThread.AddTagAVSet(GetActorValueSetForm(aSetAV), aSetAV.fValue)
-			endif
-			
-			kThread.bStartEnabled = abStartEnabled
-			kThread.bForceStatic = aPlaceMe.bForceStatic
-			kThread.kSpawnAt = PlayerRef
-			kThread.SpawnMe = FormToPlace
-			kThread.fPosX = aPlaceMe.fPosX
-			kThread.fPosY = aPlaceMe.fPosY
-			kThread.fPosZ = aPlaceMe.fPosZ
-			kThread.fAngleX = aPlaceMe.fAngleX
-			kThread.fAngleY = aPlaceMe.fAngleY
-			kThread.fAngleZ = aPlaceMe.fAngleZ
-			kThread.fScale = aPlaceMe.fScale
-			kThread.kWorkshopRef = akWorkshopRef
-			
-			kThread.RunCode()
-			
-			ObjectReference kCreatedRef = kThread.kResult
-			
-			if( ! kThread.bAwaitingOnLoadEvent)
-				kThread.ReleaseObjectReferences()
-				kThread.SelfDestruct()
-			endif
-			
-			return kCreatedRef
-		endif
-	endif
-		
-	return None
-EndFunction
-
-
-Int Function ScrapObject(ObjectReference akScrapMe, Bool abCallbackEventNeeded = true)
-	; Send creation request to the thread manager
-	String sCustomCallbackID = sThreadID_ObjectRemoved
-	if( ! abCallbackEventNeeded)
-		sCustomCallbackID = ""
-	else
-		ModTrace("[WSFW] PlaceObjectManager: Creating ScrapObject thread - requesting callback event.")
-	endif
-		
-	WorkshopFramework:ObjectRefs:Thread_ScrapObject kThread = ThreadManager.CreateThread(ScrapObjectThread) as WorkshopFramework:ObjectRefs:Thread_ScrapObject
+Function SendBatchEvent(ActorValue aWithAV, Float afWithAVValue, ObjectReference[] akSendRefs, Bool abMoreEventsComing = false)
+	Var[] kArgs = new Var[0]
 	
-	if(kThread)
-		kThread.kScrapMe = akScrapMe
-					
-		int iCallBackID = ThreadManager.QueueThread(kThread, sCustomCallbackID)
+	kArgs.Add(aWithAV)
+	kArgs.Add(afWithAVValue)
+	kArgs.Add(abMoreEventsComing)
+	
+	int i = 0 
+	while(i < akSendRefs.Length)
+		kArgs.Add(akSendRefs[i])
 		
-		return iCallBackID
-	endif	
-		
-	return -1
+		i += 1
+	endWhile
+	
+	SendCustomEvent("ObjectBatchCreated", kArgs)
 EndFunction
 
 
@@ -409,22 +657,6 @@ Function ClearSentObjects()
 EndFunction
 
 
-Function SendBatchEvent(ActorValue aWithAV, Float afWithAVValue, ObjectReference[] akSendRefs, Bool abMoreEventsComing = false)
-	Var[] kArgs = new Var[0]
-	
-	kArgs.Add(aWithAV)
-	kArgs.Add(afWithAVValue)
-	kArgs.Add(abMoreEventsComing)
-	
-	int i = 0 
-	while(i < akSendRefs.Length)
-		kArgs.Add(akSendRefs[i])
-		
-		i += 1
-	endWhile
-	
-	SendCustomEvent("ObjectBatchCreated", kArgs)
-EndFunction
 
 Int Function MonitorBatch(ObjectWatch aBatch)
 	if( ! QueuedBatches)
@@ -458,6 +690,7 @@ Function UpdateMonitors(ObjectReference akPlacedRef)
 	while(i < QueuedBatches.Length)
 		ModTrace("[WSFW] UpdateMonitors, testing " + akPlacedRef + " with batch value: " + akPlacedRef.GetValue(QueuedBatches[i].WithAV) + " against monitor: " + QueuedBatches[i])
 		
+		; TODO: Testing each item for an AV is likely slowing this code down - would probably be faster to instead setup a number of RefCollectionAliases = to the max batch count and just store the items in the appropriate ref collection - then just send all of those items to the requestor. We can then repurpose the alias used by FetchMyObjects to handle individual object creation calls.
 		if(QueuedBatches[i].WithAV && akPlacedRef.GetValue(QueuedBatches[i].WithAV) == QueuedBatches[i].WithAVValue)
 			QueuedBatches[i].iSeenObjectCount += 1
 			

--- a/Scripts/Source/User/WorkshopFramework/WorkshopObjectManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopObjectManager.psc
@@ -1,0 +1,112 @@
+; ---------------------------------------------
+; WorkshopFramework:WorkshopObjectManager.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below.
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDIT
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:WorkshopObjectManager extends WorkshopFramework:Library:SlaveQuest
+{ Handles special types of Workshop Objects that need management }
+
+
+import WorkshopFramework:Library:DataStructures
+import WorkshopFramework:Library:UtilityFunctions
+import WorkshopFramework:WorkshopFunctions
+
+
+; ---------------------------------------------
+; Consts
+; ---------------------------------------------
+
+int iBatchSize = 10 ; Every X items found will be threaded out
+int iMinCountForThreading = 30 ; Must find at least this many items before we bother threading
+
+; ---------------------------------------------
+; Editor Properties 
+; ---------------------------------------------
+
+Group Controllers
+	WorkshopFramework:MainThreadManager Property ThreadManager Auto Const Mandatory
+	; TODO - Global to allow players to set Invis to never appear in workshop mode
+EndGroup
+
+Group Assets
+	Form Property Thread_ToggleInvisibleWorkshopObjects Auto Const Mandatory
+EndGroup
+
+Group Keywords
+	Keyword Property InvisibleWorkshopObjectKeyword Auto Const Mandatory
+EndGroup
+
+; ---------------------------------------------
+; Vars
+; ---------------------------------------------
+
+
+; ---------------------------------------------
+; Events
+; ---------------------------------------------
+
+Event OnMenuOpenCloseEvent(string asMenuName, bool abOpening)
+    if(asMenuName== "WorkshopMenu")
+		ToggleInvisibleWorkshopObjects(abOpening)
+	endif
+EndEvent
+
+
+; ---------------------------------------------
+; Event Handlers
+; ---------------------------------------------
+
+Function HandleQuestInit()
+	Parent.HandleQuestInit()
+	
+	RegisterForMenuOpenCloseEvent("WorkshopMenu")
+EndFunction
+
+; ---------------------------------------------
+; Functions
+; ---------------------------------------------
+
+Function ToggleInvisibleWorkshopObjects(Bool abOpening)
+	WorkshopScript thisWorkshop = GetNearestWorkshop(PlayerRef)
+	ObjectReference[] kInvisibleObjects = thisWorkshop.FindAllReferencesWithKeyword(InvisibleWorkshopObjectKeyword, 20000.0)
+	
+	int iTotal = kInvisibleObjects.Length
+	
+	if(iTotal > iMinCountForThreading)
+		int i = 0
+		while(i < iTotal)
+			WorkshopFramework:ObjectRefs:Thread_ToggleInvisibleWorkshopObjects kThreadRef = ThreadManager.CreateThread(Thread_ToggleInvisibleWorkshopObjects) as WorkshopFramework:ObjectRefs:Thread_ToggleInvisibleWorkshopObjects
+			
+			if(kThreadRef)
+				int j = i
+				int iMaxIndex = i + iBatchSize
+				while(j < iTotal && j < iMaxIndex)
+					kThreadRef.kObjectRefs.Add(kInvisibleObjects[j])
+					
+					j += 1
+				endWhile
+				
+				kThreadRef.bInWorkshopMode = abOpening
+				
+				ThreadManager.QueueThread(kThreadRef)
+			endif
+		
+			i += iBatchSize
+		endWhile
+	else
+		int i = 0
+		while(i < iTotal)
+			(kInvisibleObjects[i] as WorkshopFramework:ObjectRefs:InvisibleWorkshopObject).Toggle(abOpening)
+			
+			i += 1
+		endWhile
+	endif
+EndFunction

--- a/Scripts/Source/User/WorkshopScript.psc
+++ b/Scripts/Source/User/WorkshopScript.psc
@@ -194,6 +194,9 @@ Group WSFW_Globals
 	
 	; 1.0.4 - Give players means to turn the happiness loss of control feature off
 	GlobalVariable Property WSFW_Setting_AllowSettlementsToLeavePlayerControl Auto Hidden
+	
+	; 1.0.5 - Give player means to disable shelter mechanic
+	GlobalVariable Property WSFW_Setting_ShelterMechanic Auto Hidden
 EndGroup
 
 Group WSFW_AVs
@@ -343,6 +346,7 @@ int iFormID_Setting_actorDeathHappinessModifier = 0x000091DC Const
 int iFormID_Setting_maxAttackStrength = 0x000091DE Const
 int iFormID_Setting_maxDefenseStrength = 0x000091E0 Const
 int iFormID_Setting_AdjustMaxNPCsByCharisma = 0x0000A98D Const ; 1.0.4 - Fixed typo in form ID
+int iFormID_Setting_ShelterMechanic = 0x00006B5D ; 1.0.5
 int iFormID_Setting_RobotHappinessLevel = 0x000035D8 Const
 int iFormID_Setting_AllowSettlementsToLeavePlayerControl = 0x00004CF3 ; 1.0.4 - New setting
 int iFormID_AV_minProductivity = 0x00007338 Const
@@ -1504,6 +1508,9 @@ endFunction
 
 
 Event OnInit()
+	; WSFW - 1.0.5 - Imperative that all vars are loaded. This will slow down the init, but will ensure we don't run into any None forms
+	WorkshopParent.FillWSFWVars()
+	
 	; WSFW - 1.0.3
 	FillWSFWVars() 
 	
@@ -2077,6 +2084,12 @@ Function WSFW_DailyUpdate_AdjustResourceValues(WorkshopDataScript:WorkshopRating
 	Float fProductivity = GetProductivityMultiplier(ratings)
 	Int iAvailableBeds = GetBaseValue(Beds) as int
 	Int iSheltedBeds = GetValue(Beds) as int
+	
+	; 1.0.5 - Added option to turn off the shelter mechanic as it's very buggy
+	if(WSFW_Setting_ShelterMechanic.GetValue() == 0.0)
+		iSheltedBeds = iAvailableBeds
+	endif
+	
 	Int iSafety = GetValue(Safety) as int
 	Int iSafetyDamage = GetValue(DamageSafety) as int
 
@@ -2726,7 +2739,6 @@ endFunction
 ; we don't normally want to do this when unloaded or everything will be 0
 ; TRUE = we did recalc; FALSE = we didn't
 bool function RecalculateWorkshopResources(bool bOnlyIfLocationLoaded = true)
-	return true
 	;if bOnlyIfLocationLoaded == false || myLocation.IsLoaded()
 	
 	;UFO4P 2.0.4 Bug #24122: replaced the previous line with the following line:
@@ -2978,6 +2990,11 @@ Function FillWSFWVars()
 
 	if( ! WSFW_Setting_maxDefenseStrength)
 		WSFW_Setting_maxDefenseStrength = Game.GetFormFromFile(iFormID_Setting_maxDefenseStrength, sWSFW_Plugin) as GlobalVariable
+	endif
+	
+	; 1.0.5
+	if( ! WSFW_Setting_ShelterMechanic)
+		WSFW_Setting_ShelterMechanic = Game.GetFormFromFile(iFormID_Setting_ShelterMechanic, sWSFW_Plugin) as GlobalVariable
 	endif
 
 	if( ! WSFW_Setting_AdjustMaxNPCsByCharisma)


### PR DESCRIPTION
-Switched to Utility.WaitMenuMode for the locking mechanism in all control quests.
-GetLock on all quests extended from LockableQuest now use a variable wait time. Rather than waiting 0.1 seconds, before the loop starts, a random value between 0.10 and 0.50 is assigned as the wait time, then each loop that the lock is still being held that much time will be allowed to pass. This should greatly reduce the likelihood of a quest becoming dead-locked due to an excessive number of simultaneous calls.
-GetLock on all quests extended from LockableQuest now have an auto-clearing lock feature after a request has lasted a certain amount of time, any extending quest may override the total wait time. The default time is currently very long (between 10 and 50 seconds - see previous change to wait time), and is not expected to be hit unless a large burst of requests come in that cause the quest to essentially become dead-locked.
-Added more streamlined version of the batch object creation code to the API.
-Thread_PlaceObject now has a bFadeIn property. When set to false, and bStartEnabled = true, the item will pop into existence - this is much faster than fading.
-API calls to create settlement objects will use the new bFadeIn property to ensure the items are created as quickly as possible.
-HUDFramework Wrapper will now return on all functions if it is not installed, rather than allowing the calls to error out.
-WorkshopResourceManager now uses a queue to handle resource objects built in remote settlements. Before it was using an edit lock function in the WorkshopObjectBuilt event handler - which when hit with something like a Sim Settlements City Plan or Transfer Settlements blueprint would completely lock up.
-Added WorkshopObjectManager quest to handle special case workshop objects that require a lot of handling. In the future, this will be used to centralize some of the things currently being handled by events on individual objects via WorkshopObjectScript - which can end up causing bursts of threaded activity which can occasionally put too heavy a load on the VM.
-Added WorkshopObjectScript extended script called InvisibleWorkshopObject. This allows for creating workshop objects that act as handles for something that is normally invisible, such as Animation Markers. The InvisibleWorkshopObject has a new field called ControlledObjectForm which will hold the base form of the item that should remain visible - a reference of this will be created when the InvisibleWorkshopObject is placed. The InvisibleWorkshopObject will automatically disappear when the player exits workshop mode, leaving the ControlledObject it spawns enabled.
-Added new Holotape/MCM option to disable the Shelter Mechanic so that you no longer receive happiness penalties from not having a roof over your beds. The Shelter Mechanic is a system in the base game that is very buggy. For many users, this system does not correctly detect roofs and it can feel like the happiness penalty is permanent no matter where beds are.