### PR TITLE
v 1.1.3

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Aliases/ConfigureSpawnedAssaultNPCs.psc
+++ b/Scripts/Source/User/WorkshopFramework/Aliases/ConfigureSpawnedAssaultNPCs.psc
@@ -1,0 +1,15 @@
+Scriptname WorkshopFramework:Aliases:ConfigureSpawnedAssaultNPCs extends RefCollectionAlias
+
+Spell Property NeutralAggression Auto Const
+Faction Property SettlementFriendlyFaction Auto Const
+
+Event OnLoad(ObjectReference akSender)
+	Actor thisActor = akSender as Actor
+	if(SettlementFriendlyFaction)
+		thisActor.AddToFaction(SettlementFriendlyFaction)
+	endif
+	
+	if(NeutralAggression)
+		thisActor.AddSpell(NeutralAggression, abVerbose = false)
+	endif
+EndEvent

--- a/Scripts/Source/User/WorkshopFramework/Aliases/RemoveOnDeath.psc
+++ b/Scripts/Source/User/WorkshopFramework/Aliases/RemoveOnDeath.psc
@@ -1,0 +1,21 @@
+Scriptname WorkshopFramework:Aliases:RemoveOnDeath extends ReferenceAlias
+
+Keyword Property IdentifierKeyword Auto Const Mandatory
+{ Make sure this keyword is applied as part of the alias. }
+
+Event OnDeath(Actor akKiller)
+	if( ! akKiller)
+		akKiller = Game.GetPlayer()
+	endif
+	
+	ObjectReference[] IdentifiedRefs = akKiller.FindAllReferencesWithKeyword(IdentifierKeyword, 20000.0)
+	
+	int i = 0
+	while(i < IdentifiedRefs.Length)
+		if((IdentifiedRefs[i] as Actor).IsDead())
+			RemoveFromRef(IdentifiedRefs[i])
+		endif
+		
+		i += 1
+	endWhile
+EndEvent

--- a/Scripts/Source/User/WorkshopFramework/AssaultManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/AssaultManager.psc
@@ -165,7 +165,7 @@ EndFunction
 Function HandleInstallModChanges()
 	; Make sure we are registered for any new assault quests
 	RegisterDefaultAssaultQuests()
-	
+		
 	Parent.HandleInstallModChanges()
 EndFunction
 
@@ -194,6 +194,10 @@ Function RegisterNewAssaultQuest(Quest akQuestRef)
 EndFunction
 
 
+Int Function CountAssaultsRunning()
+	return RunningQuests.Length
+EndFunction
+
 Int Function SetupNewAssault(Location akTargetLocation, Int aiType, Bool abInvolvePlayer = true, ObjectReference akCustomVerb = None)
 	; Generate new reserve ID
 	Int iReserveID = NextReserveID
@@ -210,9 +214,16 @@ Int Function SetupNewAssault(Location akTargetLocation, Int aiType, Bool abInvol
 	
 	if(abInvolvePlayer)
 		if(Event_PlayerInvolvedAssault.SendStoryEventAndWait(akTargetLocation, akRef1 = akCustomVerb, aiValue1 = aiType, aiValue2 = iReserveID))
-			while( ! FindAssaultQuest(iReserveID))
+			int iWaitCount = 0
+			int iMaxWaitCount = 10
+			while( ! FindAssaultQuest(iReserveID) && iWaitCount < iMaxWaitCount)
 				Utility.Wait(1.0) ; Give the quest time to start
+				iWaitCount += 1
 			endWhile
+			
+			if(iWaitCount >= iMaxWaitCount) ; Failed to retrieve quest - let's not get stuck here
+				return -1 
+			endif
 			
 			return iReserveID
 		else

--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -30,11 +30,12 @@ CustomEvent PlayerExitedSettlement
 ; ---------------------------------------------
 
 Group Controllers
-	WorkshopParentScript Property WorkshopParent Auto Const
+	WorkshopParentScript Property WorkshopParent Auto Const Mandatory
 	WorkshopTutorialScript Property TutorialQuest Auto Const
 	{ 1.0.7 - Adding ability to control this quest }
 	GlobalVariable Property Setting_WorkshopTutorialsEnabled Auto Const
 	{ 1.0.7 - Toggle to track whether the tutorial messages were last turned on or off }
+	WorkshopFramework:AssaultManager Property AssaultManager Auto Const Mandatory
 EndGroup
 
 Group Aliases
@@ -210,6 +211,31 @@ Function HandleStageSet(Quest akQuestRef, int auiStageID, int auiItemID)
 	endif
 	
 	Parent.HandleStageSet(akQuestRef, auiStageID, auiItemID)
+EndFunction
+
+
+Function HandleInstallModChanges()
+	if(iInstalledVersion < 15) ; Patch 1.1.2
+		int i = 1
+		bool bStuckFound = false
+		while(i < AssaultManager.DefaultAssaultQuests.Length)
+			; Prior to this patch, we had only added the first quest to the default array, so any from index 1 on could be stuck
+			if(AssaultManager.DefaultAssaultQuests[i].IsRunning())
+				bStuckFound = true
+				AssaultManager.DefaultAssaultQuests[i].Stop()
+			endif
+			
+			i += 1
+		endWhile
+		
+		if(bStuckFound || AssaultManager.CountAssaultsRunning() == 0)
+			; Reboot AssaultManager quest
+			AssaultManager.Stop()
+			AssaultManager.Start()
+		endif
+	endif
+	
+	Parent.HandleInstallModChanges()
 EndFunction
 
 

--- a/Scripts/Source/User/WorkshopFramework/WorkshopControlManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopControlManager.psc
@@ -136,11 +136,11 @@ Function CaptureSettlement(WorkshopScript akWorkshopRef, FactionControl aFaction
 	Faction thisFaction = GetFactionFromFactionData(aFactionData)
 	
 	if(thisFaction != PreviousControllingFaction)
-		if(aFactionData)
+		if(aFactionData && aFactionData.ControlledSettlementCount)
 			aFactionData.ControlledSettlementCount.Mod(1)
 		endif
 		
-		if(PreviousControllingFaction != None && PreviousControlData)
+		if(PreviousControllingFaction != None && PreviousControlData && PreviousControlData.ControlledSettlementCount)
 			PreviousControlData.ControlledSettlementCount.Mod(-1)
 		endif
 	endif

--- a/Scripts/Source/User/WorkshopFramework/WorkshopResourceManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopResourceManager.psc
@@ -477,6 +477,10 @@ EndFunction
 Function HandleInstallModChanges()
 	SetupAllWorkshopProperties() ; 1.0.8 - Confirm any new properties are configured each patch
 	
+	if(iInstalledVersion < 15)
+		WorkshopParent.WSFWPatch112Fix()
+	endif
+	
 	if(iInstalledVersion < 12)
 		; 1.0.8 - Starting resource shortage loop
 		StartTimerGameTime(fTimerLength_CheckResourceShortages, iTimerID_CheckResourceShortages)


### PR DESCRIPTION
-Assault quests should now permanently change the aggression and allegiance of spawned defenders so they don’t attack settlers or animals after the assaults end.
-Assault quests will now automatically clear any objectives if the quest is stopped for any reason.
-Captive, Caravan, and non-workshop NPCs will no longer be required to be defeated to complete Assaults. This should eliminate an issue where an assault could become stuck if the wrong type of NPC ended up in the list of defenders.
-Attackers on assaults will now be removed from the default Crime Faction for that settlement, which will fix an issue where the attackers could end up turning on the player as well.