### PR TITLE
Added quest objective checking support

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Library/DataStructures.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/DataStructures.psc
@@ -67,6 +67,22 @@ Struct QuestStageSet
 	{ If set to true, this will instead look to see that this stage is NOT complete }
 EndStruct
 
+; 1.1.12 - Expanding common structure options
+Struct QuestObjectiveSet
+	Quest QuestForm = None
+	{ Quest form. [Optional] Either this, or iFormID + sPluginName have to be set. }
+	Int iFormID = -1
+	{ Decimal conversion of the last 6 digits of a forms Hex ID. [Optional] Either this + sPluginName, or ObjectForm have to be set. }
+	String sPluginName = ""
+	{ Exact file name the form is from (ex. Fallout.esm). [Optional] Either this + iFormID, or ObjectForm have to be set. }
+	
+	Int iObjective = 0
+	{ The objective to check on this quest }
+
+	Int iCompareMethod = 1
+	{ 1 means the objective must be completed, 0 means the objective most not be failed and must not be completed, -1 means the objective must be failed }
+EndStruct
+
 ; 1.0.4 - Expanding common structure options
 Struct PluginCheck
 	String PluginName

--- a/Scripts/Source/User/WorkshopFramework/Library/UtilityFunctions.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/UtilityFunctions.psc
@@ -424,6 +424,33 @@ EndFunction
 
 
 ; -----------------------------------
+; GetQuestObjectiveSetForm 
+;
+; Description: Returns the form from a WorkshopFramework:Library:DataStructures:QuestStageSet struct
+;
+; Added: 1.1.12
+; -----------------------------------
+
+Quest Function GetQuestObjectiveSetForm(QuestObjectiveSet aQuestSet) global
+	if( ! aQuestSet)
+		return None
+	endif
+	
+	Quest thisForm
+	
+	if(aQuestSet.QuestForm)
+		thisForm = aQuestSet.QuestForm
+	elseif(aQuestSet.iFormID > 0 && aQuestSet.sPluginName != "" && Game.IsPluginInstalled(aQuestSet.sPluginName))
+		thisForm = Game.GetFormFromFile(aQuestSet.iFormID, aQuestSet.sPluginName) as Quest
+	else
+		return None
+	endif
+	
+	return thisForm
+EndFunction
+
+
+; -----------------------------------
 ; CheckQuestStageSet
 ; 
 ; Description: Checks if a QuestStageSet passes
@@ -441,6 +468,33 @@ Bool Function CheckQuestStageSet(QuestStageSet aQuestSet) global
 			return ! bIsStageDone ; Return the opposite as this check wants this stage to NOT be complete
 		else
 			return bIsStageDone
+		endif
+	endif
+	
+	; Quest not found
+	return false
+EndFunction
+
+
+
+; -----------------------------------
+; CheckQuestObjectiveSet
+; 
+; Description: Checks if a QuestObjectiveSet passes
+;
+; Added: 1.1.12
+; -----------------------------------
+
+Bool Function CheckQuestObjectiveSet(QuestObjectiveSet aQuestObjectiveSet) global
+	Quest thisForm = GetQuestObjectiveSetForm(aQuestObjectiveSet)
+	
+	if(thisForm)
+		if(aQuestObjectiveSet.iCompareMethod == -1)
+			return thisForm.IsObjectiveFailed(aQuestObjectiveSet.iObjective)
+		elseif(aQuestObjectiveSet.iCompareMethod == 0)
+			return !thisForm.IsObjectiveFailed(aQuestObjectiveSet.iObjective) && !thisForm.IsObjectiveCompleted(aQuestObjectiveSet.iObjective)
+		elseif(aQuestObjectiveSet.iCompareMethod == 1)
+			return thisForm.IsObjectiveCompleted(aQuestObjectiveSet.iObjective)
 		endif
 	endif
 	


### PR DESCRIPTION
New QuestObjectiveSet struct.
New GetQuestObjectiveSetForm function which retrieves the quest from a QuestObjectiveSet struct.
New CheckQuestObjectiveSet function which checks a QuestObjectiveSet struct.

Quest objective checking is similar in function to quest stage checking, with the main difference being quest objectives can have a trinary state of uncompleted, completed, or failed.  The QuestObjectiveSet's iCompareMethod can be used to change which state the QuestObjectiveSet is checking.  
1 = Completed 
0 = Uncompleted (and not failed) 
-1 = Failed