### PR TITLE
WorkshopParentScript settler count fix

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/AssaultManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/AssaultManager.psc
@@ -274,7 +274,7 @@ EndFunction
 
 
 Bool Function SetupOptions(int aiReserveID, Bool abDisableFastTravel = true, Bool abSettlersAreDefenders = true, Bool abRobotsAreDefenders = true, Bool abAutoStartAssaultOnLoad = true, Bool abAutoStartAssaultWhenPlayerReachesAttackFrom = true, Bool abMoveAttackersToStartPoint = true, Bool abMoveDefendersToCenterPoint = true, Bool abAttackersDeadFailsAssault = true, Bool abAutoHandleObjectives = true, Bool abGuardsKillableEvenOnSubdue = false, Bool abAttackersKillableEvenOnSubdue = false, Bool abAlwaysSubdueUniques = true, Bool abChildrenFleeDuringAttack = true)
-	SetupOptionsV2(aiReserveID, abDisableFastTravel, abSettlersAreDefenders, abRobotsAreDefenders, abAutoStartAssaultOnLoad, abAutoStartAssaultWhenPlayerReachesAttackFrom, abMoveAttackersToStartPoint, abMoveDefendersToCenterPoint, abAttackersDeadFailsAssault, abAutoHandleObjectives, abGuardsKillableEvenOnSubdue, abAttackersKillableEvenOnSubdue, abAlwaysSubdueUniques, abChildrenFleeDuringAttack)
+	return SetupOptionsV2(aiReserveID, abDisableFastTravel, abSettlersAreDefenders, abRobotsAreDefenders, abAutoStartAssaultOnLoad, abAutoStartAssaultWhenPlayerReachesAttackFrom, abMoveAttackersToStartPoint, abMoveDefendersToCenterPoint, abAttackersDeadFailsAssault, abAutoHandleObjectives, abGuardsKillableEvenOnSubdue, abAttackersKillableEvenOnSubdue, abAlwaysSubdueUniques, abChildrenFleeDuringAttack)
 EndFunction
 
 

--- a/Scripts/Source/User/WorkshopFramework/Fragments/Quests/QF_SS2_PlotManager_02002ABD.psc
+++ b/Scripts/Source/User/WorkshopFramework/Fragments/Quests/QF_SS2_PlotManager_02002ABD.psc
@@ -1,5 +1,5 @@
 ;BEGIN FRAGMENT CODE - Do not edit anything between this and the end comment
-Scriptname Fragments:Quests:QF_SS2_PlotManager_02002ABD Extends Quest Hidden Const
+Scriptname WorkshopFramework:Fragments:Quests:QF_SS2_PlotManager_02002ABD Extends Quest Hidden Const
 
 ;BEGIN FRAGMENT Fragment_Stage_0100_Item_00
 Function Fragment_Stage_0100_Item_00()

--- a/Scripts/Source/User/WorkshopFramework/Library/ThreadRunner.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ThreadRunner.psc
@@ -383,7 +383,8 @@ Bool Function RunGlobalFunctionThread(Int aiCallBackID, String asCustomCallbackI
 	; Release Edit Lock
 	if(ReleaseLock(iLockKey) < GENERICLOCK_KEY_NONE )
         ModTrace("Failed to release lock " + iLockKey + "!", 2)
-    endif	
+    endif
+	return false
 EndFunction
 
 

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
@@ -27,7 +27,7 @@ String sPlugin_Fallout4 = "Fallout4.esm" Const
 int iFormID_InvisibleWorkshopObjectKeyword = 0x00006B5A Const
 int iFormID_WorkshopItemKeyword = 0x00054BA6 Const
 int iFormID_WorkshopWorkObject = 0x00020592 Const
-int iFormID_WorkshopStackedItemParentKeyword = 0X001C5EDD Const
+int iFormID_WorkshopStackedItemParentKeyword = 0x001C5EDD Const
 int iFormID_LayoutExportDisabledKeyword = 0x0002B79D Const ; LinkDisable
 ; ---------------------------------------------
 ; Editor Properties 

--- a/Scripts/Source/User/WorkshopFramework/PlaceObjectManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/PlaceObjectManager.psc
@@ -495,6 +495,7 @@ EndFunction
 ; 1.0.5 - Added Private version so we could add additional args
 Int Function CreateObject(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true)
 	int iThreadCallbackID = CreateObject_Private(aPlaceMe, akWorkshopRef, aSetAV, aiFormlistIndex, akPositionRelativeTo, abStartEnabled, abCallbackEventNeeded, sThreadID_ObjectCreated, aiBatchID = -1)
+	return iThreadCallbackID
 EndFunction
 
 Int Function CreateObject_Private(WorldObject aPlaceMe, WorkshopScript akWorkshopRef = None, ActorValueSet aSetAV = None, Int aiFormlistIndex = -1, ObjectReference akPositionRelativeTo = None, Bool abStartEnabled = true, Bool abCallbackEventNeeded = true, String asCustomCallBackID = "", Int aiBatchID = -1)

--- a/Scripts/Source/User/WorkshopFramework/WorkshopProductionManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopProductionManager.psc
@@ -951,7 +951,7 @@ EndFunction
 
 ; 1.0.8 - Calling V2 for backwards compatibility
 Int Function ConsumeFromWorkshop(Form aConsumeMe, Int aiCount, WorkshopScript akWorkshopRef, Keyword aTargetContainerKeyword = None, Bool abIsComponentFormList = false, Bool abLinkedWorkshopConsumption = false)
-	ConsumeFromWorkshopV2(aConsumeMe, aiCount, akWorkshopRef, aTargetContainerKeyword, abIsComponentFormList, abLinkedWorkshopConsumption, abCheckOnly = false)
+	return ConsumeFromWorkshopV2(aConsumeMe, aiCount, akWorkshopRef, aTargetContainerKeyword, abIsComponentFormList, abLinkedWorkshopConsumption, abCheckOnly = false)
 EndFunction
 
 
@@ -1170,7 +1170,7 @@ EndFunction
 
 ; 1.0.8 - Calling V2 for backwards compatibility
 Int Function ConsumeResource(ObjectReference akContainerRef, Form aConsumeMe, Int aiCount, Bool abComponentFormList = false)
-	ConsumeResourceV2(akContainerRef, aConsumeMe, aiCount, abComponentFormList, abCheckOnly = false)
+	return ConsumeResourceV2(akContainerRef, aConsumeMe, aiCount, abComponentFormList, abCheckOnly = false)
 EndFunction
 
 

--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -2625,7 +2625,7 @@ function AddActorToWorkshop(WorkshopNPCScript assignedActor, WorkshopScript work
 
 	assignedActor.EvaluatePackage()
 
-	if( ! workshopRef.RecalculateWorkshopResources())
+	if(!bResetMode && !workshopRef.RecalculateWorkshopResources())
 		; WSWF - Added if(assignedActor.bCountsForPopulation) to ensure it isn't increased when sending those NPCs
 		if(assignedActor.bCountsForPopulation)
 			ModifyResourceData(WorkshopRatings[WorkshopRatingPopulation].resourceValue, workshopRef, 1)


### PR DESCRIPTION
Fixed the bug where WorkshopParentScript can count settlers twice under certain circumstances, as much as doubling recorded settler count in the process.

Also fixed a handful of minor bugs my compiler complained about, mostly functions missing a return value. I'm not entirely sure if these matter, but the original intentions are clear.