### PR TITLE
Also disable WorkshopResourceManager.FixSettlerCount()

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
@@ -27,7 +27,7 @@ String sPlugin_Fallout4 = "Fallout4.esm" Const
 int iFormID_InvisibleWorkshopObjectKeyword = 0x00006B5A Const
 int iFormID_WorkshopItemKeyword = 0x00054BA6 Const
 int iFormID_WorkshopWorkObject = 0x00020592 Const
-int iFormID_WorkshopStackedItemParentKeyword = 0X001C5EDD Const
+int iFormID_WorkshopStackedItemParentKeyword = 0x001C5EDD Const
 int iFormID_LayoutExportDisabledKeyword = 0x0002B79D Const ; LinkDisable
 ; ---------------------------------------------
 ; Editor Properties 

--- a/Scripts/Source/User/WorkshopFramework/WorkshopResourceManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopResourceManager.psc
@@ -265,25 +265,7 @@ Event OnTimer(Int aiTimerID)
 	if(aiTimerID == iTimerID_RecheckWithinSettlement)
 		CheckForWorkshopChange(true)
 	elseif(aiTimerID == iTimerID_FixSettlerCount)
-		Bool bSettlerCountStable = false
-		ObjectReference kWorkshopRef = LatestWorkshop.GetRef()
-		if(kWorkshopRef)
-			Float fPopulationValue = kWorkshopRef.GetValue(Population)
-			
-			while( ! bSettlerCountStable)
-				; Wait for recalculateResources to complete - this can take several seconds real time and there is no event for it
-				Utility.Wait(1.0)
-				Float fCurrentPop = kWorkshopRef.GetValue(Population)
-				
-				if(fCurrentPop != fPopulationValue)
-					fPopulationValue = fCurrentPop
-				else
-					bSettlerCountStable = true
-				endif
-			endWhile
-			
-			FixSettlerCount()
-		endif
+		; do nothing
 	elseif(aiTimerID == iTimerID_DoubleCheckRemoteBuiltResources)
 		HandleRemoteBuiltResources()
 	endif
@@ -704,7 +686,6 @@ EndFunction
 
 
 Function HandleWorkshopChange(WorkshopScript akWorkshopRef)
-	FixSettlerCount() ; Do one last settler count fix before we leave - this should eliminate the pipboy display bug
 	LatestWorkshop.ForceRefTo(akWorkshopRef)
 	ClearLatestSettlementResources()
 	GatherLatestSettlementResources()
@@ -765,24 +746,7 @@ EndFunction
 
 
 Function FixSettlerCount()
-	; There is a frequent bug in the game where the settler count will end up doubled in the UI, this will attempt to fix that
-	
-	int i = 0
-	int iPopulation = 0
-	while(i < LatestSettlementResources.GetCount())
-		Actor asActor = LatestSettlementResources.GetAt(i) as Actor
-		
-		if(asActor && WorkshopFramework:WorkshopFunctions.CountsForPopulation(asActor))
-			iPopulation += 1
-		endif
-		
-		i += 1
-	endWhile
-	
-	if(iPopulation > 0)
-		ObjectReference thisWorkshop = LatestWorkshop.GetRef()
-		thisWorkshop.SetValue(Population, iPopulation as Float)
-	endif
+	; No longer necessary after fixing the WorkshopParentScript.AddActorToWorkshop() bug
 EndFunction
 
 


### PR DESCRIPTION
After additional playtesting, I found that the FixSettlerCount() function, which I had previously left alone, is no longer necessary, and also seems to have a decent chance of messing up the population count by itself. Best to just remove it.

Also re-includes my commit from a few days ago, as the pull request for that was closed rather than merged, and that's just how git works.