### PR TITLE
2.0.4

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -3,10 +3,10 @@
 ; ---------------------------------------------
 ; Reusage Rights ------------------------------
 ; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below.
-; 
+;
 ; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
-; 
+;
 ; IMPORTED SCRIPT CREDIT
 ; N/A
 ; ---------------------------------------------
@@ -28,7 +28,7 @@ Int iTimerID_BuildableAreaCheck = 100 Const
 Float fTimerLength_BuildableAreaCheck = 3.0 Const
 
 ; ---------------------------------------------
-; Editor Properties 
+; Editor Properties
 ; ---------------------------------------------
 
 Group Controllers
@@ -61,10 +61,11 @@ Group Keywords
 EndGroup
 
 Group Messages
-	; 1.0.4 - Adding new message to explain why ClaimSettlement isn't working 
+	; 1.0.4 - Adding new message to explain why ClaimSettlement isn't working
 	Message Property CannotFindSettlement Auto Const Mandatory
 	Message Property ManageSettlementMenu Auto Const Mandatory
 	Message Property ScrapConfirmation Auto Const Mandatory
+    Message Property IncreaseLimitsMenu Auto Const Mandatory
 EndGroup
 
 ; ---------------------------------------------
@@ -81,47 +82,47 @@ Int Property iSaveFileMonitor Auto Hidden ; Important - only meant to be edited 
 ; ---------------------------------------------
 
 ; ---------------------------------------------
-; Events 
+; Events
 ; ---------------------------------------------
 
 ; Extending to fire off settlement enter/exit events
 Event OnTimer(Int aiTimerID)
 	Parent.OnTimer(aiTimerID)
-	
+
 	if(aiTimerID == LocationChangeTimerID)
 		Location kPreviousLoc = PreviousLocation.GetLocation()
 		Location kNewLoc = LatestLocation.GetLocation()
 		Bool bEnteringWorkshopLocation = false
 		Bool bLeavingWorkshopLocation = false
-		
+
 		if(kNewLoc != None)
 			if(kNewLoc.HasKeyword(LocationTypeWorkshop))
 				bEnteringWorkshopLocation = true
 			endif
 		endif
-		
+
 		if(kPreviousLoc != None)
 			if(kPreviousLoc.HasKeyword(LocationTypeWorkshop))
 				bLeavingWorkshopLocation = true
 			endif
 		endif
-		
+
 		if(bEnteringWorkshopLocation || bLeavingWorkshopLocation)
 			Var[] kArgs
-			
+
 			WorkshopScript currentWorkshop = WorkshopParent.GetWorkshopFromLocation(PlayerRef.GetCurrentLocation())
 			; 1.0.4 - Added sanity check
 			if( ! currentWorkshop || ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
 				; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
 				currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
-				
+
 				if(bLeavingWorkshopLocation && ! bEnteringWorkshopLocation && currentWorkshop && ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
 					currentWorkshop = None
 				else
 					if(currentWorkshop.myLocation != None)
 						; Player is in limbo area - it is not flagged as part of a specific location (likely just the overworld location - ie. Commonwealth) and so another LocationChange event isn't likely to fire - so instead we'll do a 5 second repeating loop to check if they returned to the location tagged part of the settlement or are out of the build area
 						StartTimer(fTimerLength_BuildableAreaCheck, iTimerID_BuildableAreaCheck)
-						
+
 						; Update Latest Location so the next change will correctly be aware the player was previously in a settlement
 						LatestLocation.ForceLocationTo(currentWorkshop.myLocation)
 					else
@@ -129,64 +130,64 @@ Event OnTimer(Int aiTimerID)
 						CancelTimer(iTimerID_BuildableAreaCheck)
 					endif
 				endif
-			endif			
-			
+			endif
+
 			WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
 			Bool bCurrentWorkshopRefFound = true
 			if( ! currentWorkshop)
 				bCurrentWorkshopRefFound = false
 			endif
-			
+
 			Bool bLastWorkshopRefFound = true
 			if( ! lastWorkshop)
 				bLastWorkshopRefFound = false
-			endif			
-			
+			endif
+
 			if( ! bLastWorkshopRefFound && bCurrentWorkshopRefFound) ; This should only happen once, after which there will always be a lastWorkshop stored in the alias
 				LastWorkshopAlias.ForceRefTo(currentWorkshop)
-			endif			
-			
+			endif
+
 			;Debug.Trace(">>>>>>>>>>>>>>>> bLastWorkshopRefFound: " + bLastWorkshopRefFound + ", kPreviousLoc: " + kPreviousLoc + ", kNewLoc: " + kNewLoc + ", lastWorkshop: " + lastWorkshop + ", currentWorkshop: " + currentWorkshop + ", bCurrentWorkshopRefFound: " + bCurrentWorkshopRefFound + ", bLastSettlementUnloaded: " + bLastSettlementUnloaded)
 			if(bLastWorkshopRefFound)
 				Bool bLastWorkshopLoaded = lastWorkshop.GetCurrentLocation().IsLoaded()
 				kArgs = new Var[2]
 				kArgs[0] = lastWorkshop
 				kArgs[1] = bLastWorkshopLoaded ; Scripts can use this to determine if the player has actually left or is maybe just hanging out around the edge of the settlement
-				
+
 				if(lastWorkshop != currentWorkshop && (bCurrentWorkshopRefFound || ! bLastSettlementUnloaded))
 					; Workshop changed or they are no longer in a settlement
 					if(bCurrentWorkshopRefFound)
 						; Changed settlement - update our lastWorkshop record to store the currentWorkshop
 						LastWorkshopAlias.ForceRefTo(currentWorkshop)
 					endif
-					
+
 					if( ! bLastWorkshopLoaded)
 						; Our previous settlement is no longer loaded in memory
 						bLastSettlementUnloaded = true
-					endif				
-					
+					endif
+
 					SendCustomEvent("PlayerExitedSettlement", kArgs)
 				else
-					; Player changed location but is still in same settlement - don't send event					
-				endif	
+					; Player changed location but is still in same settlement - don't send event
+				endif
 			endif
-			
+
 			if(bCurrentWorkshopRefFound)
 				; Workshop changed or previous settlement unloaded
 				kArgs = new Var[3]
 				kArgs[0] = currentWorkshop
 				kArgs[1] = lastWorkshop
 				kArgs[2] = bLastSettlementUnloaded ; If lastWorkshop == currentWorkshop && bLastSettlementUnloaded - it means the player traveled far enough to unload the last settlement, but never visited a new one in between
-				
+
 				SendCustomEvent("PlayerEnteredSettlement", kArgs)
-				
+
 				bLastSettlementUnloaded = false ; Since we've entered a settlement, the lastWorkshop is changing
 			endif
 		endif
 	elseif(aiTimerID == iTimerID_BuildableAreaCheck)
 		WorkshopScript currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
 		Location PlayerLocation = PlayerRef.GetCurrentLocation()
-		
+
 		if(currentWorkshop && PlayerRef.IsWithinBuildableArea(currentWorkshop))
 			if(currentWorkshop.myLocation && currentWorkshop.myLocation != PlayerLocation)
 				; Player is in a limbo area of a settlement not flagged as part of the settlement - repeat this loop
@@ -199,9 +200,9 @@ Event OnTimer(Int aiTimerID)
 			Var[] kArgs = new Var[2]
 			kArgs[0] = currentWorkshop
 			kArgs[1] = bLastWorkshopLoaded ; Scripts can use this to determine if the player has actually left or is maybe just hanging out around the edge of the settlement
-			
+
 			SendCustomEvent("PlayerExitedSettlement", kArgs)
-		endif			
+		endif
 	endif
 EndEvent
 
@@ -211,14 +212,14 @@ Event OnMenuOpenCloseEvent(string asMenuName, bool abOpening)
 		if(abOpening)
 			WorkshopScript currentWorkshop = WorkshopParent.CurrentWorkshop.GetRef() as WorkshopScript
 			WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
-			
+
 			if(lastWorkshop != currentWorkshop)
 				 ; If this happens, there is likely some serious script lag happening - but since LastWorkshopAlias is used throughout our code, we don't ever want it to be incorrect, so use this opportunity to correct it
 				 if( ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
 					; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
 					currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
 				endif
-				
+
 				if(currentWorkshop)
 					LastWorkshopAlias.ForceRefTo(currentWorkshop)
 				endif
@@ -252,24 +253,24 @@ EndFunction
 Function HandleGameLoaded()
 	; Make sure our debug log is open
 	WorkshopFramework:Library:UtilityFunctions.StartUserLog()
-	
+
 	ModTrace("[WSFW] >>>>>>>>>>>>>>>>> HandleGameLoaded called on WSFW MainQuest")
-	
+
 	if(WorkshopParent.IsRunning())
 		WorkshopParent.FillWSFWVars() ; Patch 1.0.1 - Eliminating all vanilla form edits and switching to GetFormFromFile
 	else
 		RegisterForRemoteEvent(WorkshopParent as Quest, "OnStageSet")
 	endif
-	
+
 	RegisterForMenuOpenCloseEvent("WorkshopMenu")
 	UpdatePluginFlags()
-	
+
 	if( ! PlayerRef.HasPerk(ActivationPerk))
 		PlayerRef.AddPerk(ActivationPerk) ; 1.2.0 - Allow for alternate activations
 	endif
-	
+
 	StartQuests()
-	
+
 	Parent.HandleGameLoaded()
 EndFunction
 
@@ -284,7 +285,7 @@ Function HandleStageSet(Quest akQuestRef, int auiStageID, int auiItemID)
 	if(akQuestRef == WorkshopParent)
 		WorkshopParent.FillWSFWVars()
 	endif
-	
+
 	Parent.HandleStageSet(akQuestRef, auiStageID, auiItemID)
 EndFunction
 
@@ -296,30 +297,30 @@ EndFunction
 Bool Function StartQuests()
 	ModTrace("[WSFW] >>>>>>>>>>>>>>>>> WSFW MainQuest.StartQuests called.")
 	bFrameworkReady = Parent.StartQuests()
-	
+
 	return bFrameworkReady
 EndFunction
 
 ; Override parent function - to check for same location on the settlement type
 Function HandleLocationChange(Location akNewLoc)
 	Location lastParentLocation = LatestLocation.GetLocation()
-	
+
 	; Always proceed if buildable area check is running - as that indicates the player entered a limbo zone where they were within settlement bounds that were not tagged with the correct location
 	if(akNewLoc == None || lastParentLocation == None || ! akNewLoc.IsSameLocation(lastParentLocation) || ! akNewLoc.IsSameLocation(lastParentLocation, LocationTypeSettlement))
 		if(lastParentLocation == None)
 			PreviousLocation.Clear() ; 1.1.9
 		else
-			PreviousLocation.ForceLocationTo(lastParentLocation) ; 1.1.7			
+			PreviousLocation.ForceLocationTo(lastParentLocation) ; 1.1.7
 		endif
-		
+
 		if(akNewLoc == None)
 			LatestLocation.Clear()
 		else
 			LatestLocation.ForceLocationTo(akNewLoc)
 		endif
-		
-		StartTimer(1.0, LocationChangeTimerID)	
-	endif	
+
+		StartTimer(1.0, LocationChangeTimerID)
+	endif
 EndFunction
 
 
@@ -331,35 +332,97 @@ EndFunction
 ; 1.2.0 - Adding a new manage pop-up menu to workbenches to avoid the player needing to use MCM or holotape for some things
 Function PresentManageSettlementMenu(WorkshopScript akWorkshopRef)
 	int iChoice = ManageSettlementMenu.Show()
-	
+
 	if(iChoice == 0)
 		; PresentLayoutManagementMenu triggers a series of menus that loop, let's not get this main quest caught up in the thread - so instead trigger a new thread via CallFunctionNoWait
 		Var[] kArgs = new Var[1]
 		kArgs[0] = akWorkshopRef
-		
+
 		SettlementLayoutManager.CallFunctionNoWait("PresentLayoutManagementMenu", kArgs)
 	elseif(iChoice == 1)
 		; Scrap Settlement
 		int iConfirm = ScrapConfirmation.Show()
-		
+
 		if(iConfirm == 1)
 			; Clear all layouts
 			int i = 0
 			while(i < akWorkshopRef.AppliedLayouts.Length)
 				akWorkshopRef.AppliedLayouts[i].Remove(akWorkshopRef)
-				
+
 				i += 1
 			endWhile
-			
+
 			; Scrap entire settlement
 			SettlementLayoutManager.ScrapSettlement(akWorkshopRef, abScrapLinkedAndCollectLootables = true)
 		endif
 	elseif(iChoice == 2)
+        ; build limits
+        PresentIncreaseLimitsMenu(akWorkshopRef)
+	elseif(iChoice == 3)
 		; Cancel
 	endif
-	
-	; TODO - Adjust build limit menu (reset/increase/increaseLots/increaseTons)
+
 	; TODO - Claim/Unclaim workshop option  (Force take or give up control of workshop)
+EndFunction
+
+Function PresentIncreaseLimitsMenu(WorkshopScript akWorkshopRef)
+    float defaultTris  = akWorkshopRef.MaxTriangles
+    float defaultDraws = akWorkshopRef.MaxDraws
+
+    float curMaxTris  = akWorkshopRef.getValue(WorkshopParent.WorkshopMaxTriangles)
+    float curMaxDraws = akWorkshopRef.getValue(WorkshopParent.WorkshopMaxDraws)
+
+    float percentTris  = 100 * curMaxTris / defaultTris
+    float percentDraws = 100 * curMaxDraws / defaultDraws
+    
+    float percentDisplay = percentTris
+    if(percentDraws > percentTris)
+        percentDisplay = percentDraws
+    endif
+
+    float newTris  = curMaxTris
+    float newDraws = curMaxDraws
+
+    int iChoice = IncreaseLimitsMenu.show(percentDisplay)
+    
+    if(iChoice == 4)
+        ; cancel
+        return
+    endif
+    
+    if(iChoice == 3) 
+        ; reset
+        akWorkshopRef.SetValue(WorkshopParent.WorkshopMaxDraws, Math.floor(defaultDraws))
+        akWorkshopRef.SetValue(WorkshopParent.WorkshopMaxTriangles, Math.floor(defaultTris))
+        return
+    endif
+
+    float factor = 1.0
+
+    if(iChoice == 0)
+        ; +25%
+        factor = 0.25
+    elseif(iChoice == 1)
+        ; +50%
+        factor = 0.5
+    elseif(iChoice == 2)
+        ; +100%
+        factor = 1.0
+    endif
+    
+        
+    float currentDraws = akWorkshopRef.getValue(WorkshopParent.WorkshopCurrentDraws)
+    float currentTris  = akWorkshopRef.getValue(WorkshopParent.WorkshopCurrentTriangles)
+    
+    if(currentDraws > defaultDraws || currentTris > defaultTris)
+        ; use percentage of current maximum
+        akWorkshopRef.SetValue(WorkshopParent.WorkshopMaxDraws,     curMaxTris  + Math.floor(curMaxTris * factor))
+        akWorkshopRef.SetValue(WorkshopParent.WorkshopMaxTriangles, curMaxDraws + Math.floor(curMaxDraws * factor))
+    else
+        ; use percentage of default maximum
+        akWorkshopRef.SetValue(WorkshopParent.WorkshopMaxDraws,     curMaxTris  + Math.floor(defaultTris * factor))
+        akWorkshopRef.SetValue(WorkshopParent.WorkshopMaxTriangles, curMaxDraws + Math.floor(defaultDraws * factor))
+    endif
 EndFunction
 
 
@@ -368,7 +431,7 @@ Function ClaimSettlement(WorkshopScript akWorkshopRef = None)
 	if( ! akWorkshopRef)
 		akWorkshopRef = GetNearestWorkshop(PlayerRef)
 	endif
-	
+
 	if(akWorkshopRef)
 		akWorkshopRef.SetOwnedByPlayer(true)
 	else
@@ -386,14 +449,14 @@ Function DisableWorkshopTutorials()
 	TutorialQuest.UnregisterForCustomEvent(WorkshopParent, "WorkshopObjectDestructionStageChanged")
 	TutorialQuest.UnregisterForCustomEvent(WorkshopParent, "WorkshopObjectPowerStageChanged")
 	TutorialQuest.UnregisterForCustomEvent(WorkshopParent, "WorkshopEnterMenu")
-	
+
 	; Stop any existing help messages
 	int i = 0
 	while(i < TutorialQuest.TutorialSteps.Length)
 		if(TutorialQuest.TutorialSteps[i].HelpMessage)
 			TutorialQuest.TutorialSteps[i].HelpMessage.UnshowAsHelpMessage()
 		endif
-		
+
 		i += 1
 	endWhile
 EndFunction
@@ -401,12 +464,12 @@ EndFunction
 ; 1.0.7 - Adding option to toggle Workshop Tutorials
 Function EnableWorkshopTutorials()
 	TutorialQuest.InitializeQuest()
-	
+
 	; Reset all of the tutorials
 	int i = 0
 	while(i < TutorialQuest.Tutorials.Length)
 		TutorialQuest.RollBackTutorial(TutorialQuest.Tutorials[i])
-		
+
 		i += 1
 	endWhile
 EndFunction
@@ -420,7 +483,7 @@ Function UpdatePluginFlags()
 		else
 			PluginFlags[i].GlobalForm.SetValueInt(0)
 		endif
-		
+
 		i += 1
 	endWhile
 EndFunction
@@ -430,13 +493,13 @@ Function ClaimAllSettlements()
 	Int[] iHasBadMapMarkers = new Int[0]
 	; For settlements with known bad map markers we can correct them here
 	iHasBadMapMarkers.Add(0x001F0711) ; Hangman's Alley
-	
+
 	; Unlock all fast travel points
 	WorkshopScript[] Workshops = WorkshopParent.Workshops
 	int i = 0
 	while(i < Workshops.Length)
 		int iFormID = Workshops[i].GetFormID()
-		
+
 		if(Workshops[i].myMapMarker != None && iHasBadMapMarkers.Find(iFormID) < 0)
 			Workshops[i].myMapMarker.Enable(false)
 			Workshops[i].myMapMarker.AddToMap(true)
@@ -448,34 +511,34 @@ Function ClaimAllSettlements()
 				thisMapMarker.AddToMap(true)
 			endif
 		endif
-		
+
 		i += 1
 	endWhile
-	
+
 	; Reveal travel locations for NukaWorld and Far Harbor
 	if(Game.IsPluginInstalled("DLCNukaWorld.esm"))
 		ObjectReference kMapMarkerRef = Game.GetFormFromFile(0x00025515, "DLCNukaWorld.esm") as ObjectReference
-		
+
 		if(kMapMarkerRef)
 			kMapMarkerRef.Enable(false)
 			kMapMarkerRef.AddToMap(true)
 		endif
 	endif
-	
+
 	if(Game.IsPluginInstalled("DLCCoast.esm"))
 		ObjectReference kEnableParent = Game.GetFormFromFile(0x0003FEE7, "DLCCoast.esm") as ObjectReference
-		
+
 		if(kEnableParent)
 			kEnableParent.Enable(false)
-			
+
 			ObjectReference kMapMarkerRef = Game.GetFormFromFile(0x0003FEE5, "DLCCoast.esm") as ObjectReference
-			
+
 			if(kMapMarkerRef)
 				kMapMarkerRef.AddToMap(true)
 			endif
 		endif
 	endif
-	
+
 	; Handle claiming of workshops
 	WorkshopParent.ToggleOnAllWorkshops()
 EndFunction
@@ -490,7 +553,7 @@ EndFunction
 ; MCM Wrapper
 Function MCM_PresentManageSettlementMenu()
 	WorkshopScript thisWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
-	
+
 	if(thisWorkshop)
 		PresentManageSettlementMenu(thisWorkshop)
 	else

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_ScrapVanillaObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_ScrapVanillaObject.psc
@@ -1,0 +1,72 @@
+; ---------------------------------------------
+; WorkshopFramework:ObjectRefs:Thread_ScrapVanillaObject.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:ObjectRefs:Thread_ScrapVanillaObject extends WorkshopFramework:Library:ObjectRefs:Thread
+
+import WorkshopFramework:Library:DataStructures
+import WorkshopFramework:Library:UtilityFunctions
+
+; -
+; Consts
+; -
+
+
+; - 
+; Editor Properties
+; -
+WorkshopFramework:PlaceObjectManager Property PlaceObjectManager Auto Const Mandatory
+Form Property PositionHelper Auto Const Mandatory
+
+; -
+; Properties
+; -
+WorkshopScript Property kWorkshopRef Auto Hidden
+WorldObject Property ScrapObjectData Auto Hidden
+
+; -
+; Events
+; -
+
+; - 
+; Functions 
+; -
+	
+Function ReleaseObjectReferences()
+	kWorkshopRef = None
+EndFunction
+
+
+Function RunCode()
+	; Check if object exists
+	ObjectReference kPositionHelper = kWorkshopRef.PlaceAtMe(PositionHelper)
+	kPositionHelper.SetPosition(ScrapObjectData.fPosX, ScrapObjectData.fPosY, ScrapObjectData.fPosZ)
+	
+	Form BaseForm = GetWorldObjectForm(ScrapObjectData)
+	
+	ObjectReference kFoundRef = Game.FindClosestReferenceOfTypeFromRef(BaseForm, kPositionHelper, 5.0)
+	
+	; If found, is it already disabled?
+	Bool bScrapNeeded = true
+	if(kFoundRef != None)
+		if(kFoundRef.IsDisabled())
+			bScrapNeeded = false
+		endif
+	else
+		bScrapNeeded = false
+	endif
+	
+	; Found, scrap it
+	if(bScrapNeeded)
+		PlaceObjectManager.ScrapObject(kFoundRef, abCallbackEventNeeded = false)
+	endif
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/Weapons/SettlementLayoutLayer.psc
+++ b/Scripts/Source/User/WorkshopFramework/Weapons/SettlementLayoutLayer.psc
@@ -1,0 +1,17 @@
+; ---------------------------------------------
+; WorkshopFramework:Weapons:SettlementLayoutLayer.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:Weapons:SettlementLayoutLayer extends Form Const
+
+import WorkshopFramework:Library:DataStructures
+import WorkshopFramework:Library:UtilityFunctions

--- a/Scripts/Source/User/WorkshopFramework/WorkshopResourceManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopResourceManager.psc
@@ -264,26 +264,6 @@ EndEvent
 Event OnTimer(Int aiTimerID)
 	if(aiTimerID == iTimerID_RecheckWithinSettlement)
 		CheckForWorkshopChange(true)
-	elseif(aiTimerID == iTimerID_FixSettlerCount)
-		Bool bSettlerCountStable = false
-		ObjectReference kWorkshopRef = LatestWorkshop.GetRef()
-		if(kWorkshopRef)
-			Float fPopulationValue = kWorkshopRef.GetValue(Population)
-			
-			while( ! bSettlerCountStable)
-				; Wait for recalculateResources to complete - this can take several seconds real time and there is no event for it
-				Utility.Wait(1.0)
-				Float fCurrentPop = kWorkshopRef.GetValue(Population)
-				
-				if(fCurrentPop != fPopulationValue)
-					fPopulationValue = fCurrentPop
-				else
-					bSettlerCountStable = true
-				endif
-			endWhile
-			
-			FixSettlerCount()
-		endif
 	elseif(aiTimerID == iTimerID_DoubleCheckRemoteBuiltResources)
 		HandleRemoteBuiltResources()
 	endif
@@ -704,7 +684,6 @@ EndFunction
 
 
 Function HandleWorkshopChange(WorkshopScript akWorkshopRef)
-	FixSettlerCount() ; Do one last settler count fix before we leave - this should eliminate the pipboy display bug
 	LatestWorkshop.ForceRefTo(akWorkshopRef)
 	ClearLatestSettlementResources()
 	GatherLatestSettlementResources()
@@ -765,6 +744,8 @@ EndFunction
 
 
 Function FixSettlerCount()
+	return ; 2.0.4 - As of 2.0.2, this is no longer needed - removed calls to it, only retaining function for save files with calls in progress or external mods expecting it to exist
+
 	; There is a frequent bug in the game where the settler count will end up doubled in the UI, this will attempt to fix that
 	
 	int i = 0

--- a/Scripts/Source/User/WorkshopNPCScript.psc
+++ b/Scripts/Source/User/WorkshopNPCScript.psc
@@ -375,13 +375,13 @@ Event FollowersScript.CompanionChange(FollowersScript akSender, Var[] akArgs)
 EndEvent
 
 Event OnWorkshopNPCTransfer(Location akNewWorkshopLocation, Keyword akActionKW)
+	;debug.trace(self + " OnWorkshopNPCTransfer " + akNewWorkshopLocation + " keyword=" + akActionKW)
 	;WorkshopParent.wsTrace(self + " has been directed to transfer to the workshop at " + akNewWorkshopLocation + " with the " + akActionKW + " action")
 	; what kind of transfer?
 	if akActionKW == WorkshopParent.WorkshopAssignCaravan
 		WorkshopParent.AssignCaravanActorPUBLIC(self, akNewWorkshopLocation)
 	else
 		WorkshopScript newWorkshop = WorkshopParent.GetWorkshopFromLocation(akNewWorkshopLocation)
-		
 		if newWorkshop
 			if akActionKW == WorkshopParent.WorkshopAssignHome
 				WorkshopParent.AddActorToWorkshopPUBLIC(self, newWorkshop)

--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -1081,7 +1081,7 @@ CustomEvent AssignmentRulesOverriden
 ; Send data about new custom vendors
 ; aCustomVendorID - An absolute unique string across all mods using this system, this is what you'll use on the corresponding workshop furniture items in their sCustomVendorID property
 ; aVendorContainerList - A formlist with 4 container forms defined. Each entry will be added to the next for higher level vendors - for example a level 2 vendor will also get the inventory from the level 1 container. Filter for WorkshopVendorChest under WorldObjects > Containers to see an example of how to set these up.
-; aVendorKeyword - Optional to tag any NPC using this vendor type object with a keyword, which can help with things like perks or other systems to detect that an NPC is this vendor type easily
+; aVendorKeyword - Optional to tag any NPC using this vendor type object with a keyword, which can help with things like perks or other systems to detect that an NPC is this vendor type easily. 
 ; aCustomVendorFaction - If blank, this will default to WorkshopVendorFactionMisc (this is used to control dialogue). Be sure if you override this that you have your own dialogue handling in place or the settler won't actually sell anything.
 Function RegisterCustomVendor(String aCustomVendorID, Formlist aVendorContainerList, Keyword aVendorKeyword = None, Faction aCustomVendorFaction = None)
 	if(CustomVendorTypes == None)
@@ -1265,28 +1265,8 @@ function InitializeLocation(WorkshopScript workshopRef, RefCollectionAlias Settl
 		AddActorToWorkshopPUBLIC(theLeader.GetActorRef() as WorkshopNPCScript, workshopRef, true)
 	endif 
 
-	
 	initPopulation = workshopRef.GetBaseValue(WorkshopRatings[WorkshopRatingPopulation].resourceValue) as int
 	initPopulationVal = workshopRef.GetValue(WorkshopRatings[WorkshopRatingPopulation].resourceValue) as int
-	
-	; WSFW 2.0.3 - In 2.0.2, we fixed a bug that could cause population numbers to get out of sync in the pipboy. This fix had the unintended consequence of breaking behavior this section was relying on.	The below section will fix this issue. Without this, Minutemen radiant quests to help settlements will fail to find people as all population AVs will be 0.
-	if(initPopulation < SettlementNPCs.GetCount())
-		int iWorkshopNPCs = 0
-		
-		int i = 0
-		while(i < SettlementNPCs.GetCount())
-			; Need to check for WorkshopNPCScript or it will count other NPCs with Boss ref, such as the raiders occupying Outpost Zimonja
-			if((SettlementNPCs.GetAt(i) as Actor) as WorkshopNPCScript)
-				iWorkshopNPCs += 1
-			endIf
-			
-			i += 1
-		endWhile
-		
-		initPopulation = iWorkshopNPCs
-		
-		ModifyResourceData(WorkshopRatings[WorkshopRatingPopulation].resourceValue, workshopRef, initPopulation)
-	endif
 	
 	int robotPopulation = 0
 	if(workshopRef.myLocation.HasKeyword(LocTypeWorkshopRobotsOnly))
@@ -1830,7 +1810,7 @@ endFunction
 function AssignActorToObjectPUBLIC(WorkshopNPCScript assignedActor, WorkshopObjectScript assignedObject, bool bResetMode = false)
 	; lock editing
 	GetEditLock()
-	
+
 	AssignActorToObject(assignedActor, assignedObject, bResetMode = bResetMode)
 	
 	if(bResetMode)
@@ -1853,7 +1833,6 @@ function AssignActorToObject(WorkshopNPCScript assignedActor, WorkshopObjectScri
 EndFunction
 
 function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectScript assignedObject, bool bResetMode = false, bool bAddActorCheck = true, bool bUpdateObjectArray = true)
-	Debug.TraceStack("AssignActorToObjectV2 call stack.")
 	int workshopID = assignedObject.workshopID
 	WorkshopScript workshopRef
 
@@ -1930,9 +1909,6 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 			SendWorkshopActorAssignedToWorkEvent(assignedActor, assignedObject, workshopRef)
 		endif
 	elseif(assignedObject.HasKeyword(WorkshopWorkObject))
-		String sLog = "aaa"
-		Debug.OpenUserLog(sLog)
-		; Debug.TraceUser(sLog, "Assigning " + assignedActor + " to object " + assignedObject + ", bResetMode = " + bResetMode)
 		assignedActor.bNewSettler = false
 	
 		bool bShouldUnassignAllObjects = true
@@ -1941,15 +1917,12 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 		actorValue multiResourceValue = assignedActor.assignedMultiResource
 
 		if(bAlreadyAssigned)
-			; Debug.TraceUser(sLog, assignedActor + " was already assigned to object " + assignedObject)
 			bShouldUnassignAllObjects = false
 		endif
 	
 		float maxProduction = 0.0 ; Placing here so we can use this same calculated value later in the function
 		if(multiResourceValue)
-			; Debug.TraceUser(sLog, assignedActor + " was assigned to multiResourceValue " + multiResourceValue)
 			if(assignedObject.HasResourceValue(multiResourceValue))
-				; Debug.TraceUser(sLog, assignedObject + " has multiResourceValue " + multiResourceValue)
 				int resourceIndex = GetResourceIndex (multiResourceValue)
 				maxProduction = WorkshopRatings[resourceIndex].maxProductionPerNPC
 				
@@ -1961,13 +1934,8 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 				endif
 				
 				float currentProduction = assignedActor.multiResourceProduction
-				
-				; Debug.TraceUser(sLog, "Max Production: " + maxProduction + ", Current Production: " + currentProduction)
-				
 				if( ! bResetMode && bAlreadyAssigned && currentProduction <= maxProduction)
 					bShouldUnassignAllObjects = false
-					
-					; Debug.TraceUser(sLog, "Already assigned and this doesn't push us past max production. Turning off bShouldUnassignAllObjects")
 				else
 					float totalProduction = currentProduction
 					if(bResetMode || ! bAlreadyAssigned)
@@ -1975,15 +1943,12 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 					endif
 
 					if(totalProduction <= maxProduction)
-						; Debug.TraceUser(sLog, "Under or right at max production. Turning off bShouldUnassignAllObjects")
 						bShouldUnassignAllObjects = false
 					elseif(bAlreadyAssigned)
-						; Debug.TraceUser(sLog, "Already assigned but we're over max production, so we need to unassign one item.")
 						bShouldUnassignSingleObject = true
 					endif
 				endif
 			else
-				; Debug.TraceUser(sLog, assignedObject + " doesn't have multiResourceValue " + multiResourceValue + ", time to unassign the NPC from everything before assigning them to it.")
 				bShouldUnassignAllObjects = true
 			endif
 		endif
@@ -1995,7 +1960,6 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 			if(bExcludedFromAssignmentRules)
 				SendCustomEvent("AssignmentRulesOverriden", kExcludedArgs)
 			else
-				; Debug.TraceUser(sLog, "Unassigning " + assignedActor + " from " + assignedObject + ", bResetMode = " + bResetMode)
 				UnassignActorFromObjectV2(assignedActor, assignedObject, bResetMode)
 				
 				bShouldTryToAssignResources = true
@@ -2006,13 +1970,11 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 			; because there are legitimate reasons to ignore our our exclusion list, for example if the object is
 			; scrapped or the NPC is killed.
 			/;
-			; Debug.TraceUser(sLog, "Calling UnassignActorSkipExclusions on " + assignedActor + " with aLastAssigned = " + assignedObject)
 			WorkshopFramework:WorkshopFunctions.UnassignActorSkipExclusions(assignedActor, workshopRef, aLastAssigned = assignedObject)
 		endif
 
 		; unassign current owner, if any (and different from new owner)
 		if(previousOwner && previousOwner != assignedActor)
-			; Debug.TraceUser(sLog, "Calling unassign on previousOwner " + previousOwner + " so " + assignedActor + " can be assigned to " + assignedObject)
 			if(previousOwner as WorkshopNPCScript)
 				UnassignActorFromObjectV2(previousOwner as WorkshopNPCScript, assignedObject, bResetMode)
 			else
@@ -2020,8 +1982,6 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 			endif
 		endif
 
-		; Debug.TraceUser(sLog, "Calling AssignActor on " + assignedObject + " for actor " + assignedActor)
-		
 		assignedObject.AssignActor(assignedActor)
 		assignedActor.SetWorker(true)
 
@@ -2052,7 +2012,6 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 		assignedActor.EvaluatePackage()
 
 		if(assignedObject.HasMultiResource() && (bResetMode || !bAlreadyAssigned))
-			; Debug.TraceUser(sLog, assignedObject + " is a multi resource item and bResetMode = " + bResetMode + ", bAlreadyAssigned = " + bAlreadyAssigned)
 			multiResourceValue = assignedObject.GetMultiResourceValue()
 			assignedActor.SetMultiResource (multiResourceValue)
 			
@@ -2063,32 +2022,24 @@ function AssignActorToObjectV2(WorkshopNPCScript assignedActor, WorkshopObjectSc
 				if(currentProduction >= maxProduction) ; WSFW 2.0.0 - Now correctly using the user defined max production
 					WSFW_RemoveActorFromWorkerArray(assignedActor)
 				else
-					; Debug.TraceUser(sLog, "Adding " + assignedActor + " to worker array and flagging bShouldTryToAssignResources to true.")
 					WSFW_AddActorToWorkerArray(assignedActor, resourceIndex)
 					bShouldTryToAssignResources = true
 				endif
 				
 				if( ! bAlreadyAssigned && bUpdateObjectArray)
-					; Debug.TraceUser(sLog, "Removing " + assignedObject + " from unassigned objects array.")
 					UFO4P_RemoveFromUnassignedObjectsArray(assignedObject, resourceIndex)
-				else
-					; Debug.TraceUser(sLog, "Skipping removal of " + assignedObject + " from unassigned objects array. bAlreadyAssigned = " + bAlreadyAssigned + ", bUpdateObjectArray = " + bUpdateObjectArray)
 				endif
 			endif
 		endif
 
 		if(bAlreadyAssigned == false)
-			; Debug.TraceUser(sLog, "This was a new assignment so sending WorkshopActorAssignedToWorkEvent.")
 			SendWorkshopActorAssignedToWorkEvent(assignedActor, assignedObject, workshopRef)
 		endif
 
 		; WSWF - Ignore AutoAssign properties here so multi-assignment still works
 		if( ! bResetMode && bShouldTryToAssignResources && workshopID == currentWorkshopID)
-			; Debug.TraceUser(sLog, "Calling TryToAssignResourceType functions")
 			TryToAssignResourceType(workshopRef, WorkshopRatings[WorkshopRatingFood].resourceValue)
 			TryToAssignResourceType(workshopRef, WorkshopRatings[WorkshopRatingSafety].resourceValue)
-		else
-			; Debug.TraceUser(sLog, "Skipping TryToAssignResourceType functions, bResetMode = " + bResetMode + ", bShouldTryToAssignResources = " + bShouldTryToAssignResources + ", workshopID = " + workshopID + ", currentWorkshopID = " + currentWorkshopID)
 		endif		
 	endif
 endFunction
@@ -2441,7 +2392,6 @@ endFunction
 ; actorToAssign: if NONE, use the actor in WorkshopRecruit alias
 ; newWorkshopID: if -1, bring up message box to pick the workshop (TEMP)
 function AddPermanentActorToWorkshopPUBLIC(Actor actorToAssign = NONE, int newWorkshopID = -1, bool bAutoAssign = true)
-	WorkshopFramework:Library:UtilityFunctions.ModTrace("AddPermanentActorToWorkshopPUBLIC called on " + actorToAssign + " with workshop ID: " + newWorkshopID)
 	if(actorToAssign == NONE)
 		actorToAssign = WorkshopRecruit.GetActorRef()
 	elseif(actorToAssign.IsDead())
@@ -2473,7 +2423,6 @@ function AddPermanentActorToWorkshopPUBLIC(Actor actorToAssign = NONE, int newWo
 			endif
 		endif
 		
-		WorkshopFramework:Library:UtilityFunctions.ModTrace("AddPermanentActorToWorkshopPUBLIC adding " + actorToAssign + " to PermanentActorAliases " + PermanentActorAliases)
 		; add to alias collection for existing actors - gives them packages to stay at new "home"
 		PermanentActorAliases.AddRef(actorToAssign)
 		
@@ -2488,14 +2437,13 @@ function AddPermanentActorToWorkshopPUBLIC(Actor actorToAssign = NONE, int newWo
 		if(bAutoAssign && actorToAssign != DogmeatAlias.GetActorReference())
 			TryToAutoAssignNPC(newWorkshop, actorToAssign)			
 		endif
-		
-		;/ WSFW 2.0.3 - Moving to be called in AddActorToWorkshop so it fires for all actors not just uniques 
+
 		; send custom event for this actor
 		Var[] kargs = new Var[2]
 		kargs[0] = actorToAssign
 		kargs[1] = newWorkshopID
 		SendCustomEvent("WorkshopAddActor", kargs)		
-		/;
+
 		; unlock editing
 		EditLock = false
 	endif
@@ -2522,8 +2470,7 @@ function AddCollectionToWorkshopPUBLIC(RefCollectionAlias thecollection, Worksho
 			WorkshopNPCScript asWorkshopNPC = theActor as WorkshopNPCScript
 			if(asWorkshopNPC)
 				AddActorToWorkshop(asWorkshopNPC, workshopRef, bResetMode)
-			elseif( ! bResetMode && theActor.GetValue(WorkshopRatings[WorkshopRatingPopulation].resourceValue) > 0)
-				; WSFW 2.0.1 - Checking for bResetMode, as that is used by initialization scripts and we don't want to add random NPCs to the workshop like that. We only want the AddCollectionToWorkshopPUBLIC to function when modders are trying to bulk add NPCs
+			else
 				; WSFW 2.0.0 - Switching to global function for nonWorkshopNPCScript actors
 				WorkshopFramework:WorkshopFunctions.AddActorToWorkshop(theActor, workshopRef, abResetMode = bResetMode)
 			endif
@@ -2676,7 +2623,7 @@ function AddActorToWorkshop(WorkshopNPCScript assignedActor, WorkshopScript work
 
 	assignedActor.EvaluatePackage()
 
-	if( ! bResetMode && ! workshopRef.RecalculateWorkshopResources()) ; 2.0.2 - Added bResetMode check
+	if( ! workshopRef.RecalculateWorkshopResources())
 		; WSWF - Added if(assignedActor.bCountsForPopulation) to ensure it isn't increased when sending those NPCs
 		if(assignedActor.bCountsForPopulation)
 			ModifyResourceData(WorkshopRatings[WorkshopRatingPopulation].resourceValue, workshopRef, 1)
@@ -2685,15 +2632,6 @@ function AddActorToWorkshop(WorkshopNPCScript assignedActor, WorkshopScript work
 
 	if( ! bResetMode && bResetHappiness)
 		ResetHappiness (workshopRef)
-	endif
-	
-	
-	if( ! bResetMode && ! bAlreadyAssigned)
-		; WSFW 2.0.3 - Previously, this event was only being fired for unique actors which made it far less useful
-		Var[] kargs = new Var[2]
-		kargs[0] = assignedActor
-		kargs[1] = newWorkshopID
-		SendCustomEvent("WorkshopAddActor", kargs)
 	endif
 endFunction
 
@@ -3049,8 +2987,6 @@ function UnassignObject_Private(WorkshopObjectScript theObject, bool bRemoveObje
 					if(multiResourceValue && theObject.HasResourceValue(multiResourceValue))
 						float previousProduction = WorkshopFramework:WorkshopFunctions.GetMultiResourceProduction(assignedActor)
 						
-						WorkshopFramework:WorkshopFunctions.SetMultiResourceProduction(assignedActor, previousProduction - theObject.GetBaseValue(multiResourceValue))
-						
 						if(UFO4P_WorkshopID == currentWorkshopID)
 							iResourceIndexToAssign = GetResourceIndex(multiResourceValue)
 							WSFW_AddActorToWorkerArray(assignedActor, iResourceIndexToAssign)
@@ -3103,15 +3039,12 @@ endFunction
 
 function AssignObjectToWorkshop(WorkshopObjectScript workObject, WorkshopScript workshopRef, bool bResetMode = false)
 	; bResetMode: true means to ignore TryToAssignFarms/Beds calls (ResetWorkshop calls it once at the end)
-	String sLog = "aaaObject"
-	Debug.OpenUserLog(sLog)
-	; Debug.TraceUser(sLog, "AssignObjectToWorkshop called on " + workObject + ", bResetMode = " + bResetMode)
+
 	int workshopID = workshopRef.GetWorkshopID()
 	
 	Actor owner = workObject.GetActorRefOwner()
 	WorkShopNPCScript asWorkshopNPC
 	if(owner)
-		; Debug.TraceUser(sLog, workObject + " has owner " + owner)
 		asWorkshopNPC = owner as WorkshopNPCScript
 	endIf
 	
@@ -3142,12 +3075,10 @@ function AssignObjectToWorkshop(WorkshopObjectScript workObject, WorkshopScript 
 			endif
 		endif
 	else
-		; Debug.TraceUser(sLog, workObject + " is not a bed.")
 		bool UFO4P_ShouldUpdateRatings = true
 
 		;UFO4P 2.0.6 Bug #25215. removed the check for IsActorAssigned() (was superfluous with our followup check to GetAssignedActor)
 		if(workObject.HasKeyword (WorkshopWorkObject))
-			; Debug.TraceUser(sLog, workObject + " has assignable keyword WorkshopWorkObject.")
 			bool UFO4P_ShouldSendEvent = false		
 			
 			if(owner)
@@ -3228,23 +3159,16 @@ function AssignObjectToWorkshop(WorkshopObjectScript workObject, WorkshopScript 
 		endif
 
 		if(workObject.HasMultiResource() && workObject.HasKeyword(WorkshopWorkObject) && workObject.IsActorAssigned() == false)
-			; Debug.TraceUser(sLog, workObject + " has a multiResource, let's try to assign it.")
 			actorValue multiResourceValue = workObject.GetMultiResourceValue()
 			
 			;Don't try to assign damaged objects:
 			if(workObject.GetBaseValue(multiResourceValue) == workObject.GetValue(multiResourceValue))
 				UFO4P_AddObjectToObjectArray(workObject)
-				; Debug.TraceUser(sLog, workObject + " added to unassigned array.")
 				
 				if( ! bResetMode)
-					; Debug.TraceUser(sLog, "Calling TryToAssignResourceType on " + multiResourceValue)
 					TryToAssignResourceType(workshopRef, multiResourceValue)
-				else
-					; Debug.TraceUser(sLog, "bResetMode, skipping call to TryToAssignResourceType for " + workObject)
 				endif
 			endif
-		else
-			; Debug.TraceUser(sLog, "Bypassed TryToAssignResourceType section. " + workObject + " hworkObject.HasMultiResource() = " + workObject.HasMultiResource() + ", workObject.HasKeyword(WorkshopWorkObject) = " + workObject.HasKeyword(WorkshopWorkObject) + ", workObject.IsActorAssigned() = " + workObject.IsActorAssigned())
 		endif
 	endif
 endFunction
@@ -3433,13 +3357,9 @@ endFunction
 
 ; try to assign all objects of the specified resource types
 function TryToAssignResourceType(WorkshopScript workshopRef, ActorValue resourceValue)
-	String sLog = "aaaTryToAssignResourceType"
-	Debug.OpenUserLog(sLog)
-	; Debug.TraceUser(sLog, "TryToAssignResourceType called on " + workshopRef + " for AV " + resourceValue)
-	if(resourceValue)		
+	if(resourceValue)
 		int resourceIndex = GetResourceIndex(resourceValue)
 
-		; Debug.TraceUser(sLog, "resourceIndex = " + resourceIndex)
 		; WSFW 2.0.0 - Switching to nonWorkshopNPCScript arrays
 		Actor[] workers 
 		if(resourceIndex == WorkshopRatingFood)
@@ -3447,13 +3367,10 @@ function TryToAssignResourceType(WorkshopScript workshopRef, ActorValue resource
 		elseif(resourceIndex == WorkshopRatingSafety)
 			workers = WSFW_SafetyWorkers
 		else
-			; Debug.TraceUser(sLog, "No workers found for resourceIndex " + resourceIndex)
 			return
 		endif
-		
+
 		ObjectReference[] ResourceObjects = UFO4P_GetObjectArray(resourceIndex)
-		
-		; Debug.TraceUser(sLog, "Found workers " + workers + ", and resource objects " + ResourceObjects)
 		
 		int countWorkers = workers.Length
 		int countResourceObjects = ResourceObjects.Length
@@ -3476,14 +3393,11 @@ function TryToAssignResourceType(WorkshopScript workshopRef, ActorValue resource
 		
 		while(workerIndex > -1)
 			Actor theWorker = workers[workerIndex]
-			; Debug.TraceUser(sLog, "Attempting to assign settler " + theWorker + " to items...")
 			if(theWorker == none || theWorker.IsBoundGameObjectAvailable() == false)
 				workers.Remove(workerIndex)
 			else
 				; WSFW 2.0.0 - Use our global functions which work for Actors and WorkshopNPCScript actors
 				float resourceTotal = WorkshopFramework:WorkshopFunctions.GetMultiResourceProduction(theWorker)
-				
-				; Debug.TraceUser(sLog, "Attempting to assign settler " + theWorker + " to items, currently has production of " + resourceTotal)
 				
 				bool actorAssigned = false
 				int objectIndex = ResourceObjects.Length - 1
@@ -3491,35 +3405,23 @@ function TryToAssignResourceType(WorkshopScript workshopRef, ActorValue resource
 				while(objectIndex > -1 && actorAssigned == false)
 					ObjectReference theObjectRef = ResourceObjects[objectIndex]
 					WorkshopObjectScript theObject = theObjectRef as WorkshopObjectScript
-					Actor currentOwner = theObject.GetActorRefOwner()
-					; Debug.TraceUser(sLog, "Checking if settler " + theWorker + " can be assigned to " + theObject)				
+										
 					if(theObject.HasKeyword(WSFW_DoNotAutoassignKeyword)) 
-						; Debug.TraceUser(sLog, theObject + " is flagged to not be autoassigned via keyword - removing from array.")
-						ResourceObjects.Remove(objectIndex)
-					elseif(currentOwner != None && currentOwner != Game.GetPlayer())
-						; Debug.TraceUser(sLog, theObject + " already assigned, removing from array.")
-						; Object is already assigned to someone
 						ResourceObjects.Remove(objectIndex)
 					elseif(theObject.GetBaseValue(resourceValue) > theObject.GetValue(resourceValue))
-						; Debug.TraceUser(sLog, theObject + " is damaged - removing from array.")
-						; Damaged object, do not autoassign
 						ResourceObjects.Remove(objectIndex)
 					else
 						float resourceRating = theObject.GetResourceRating(resourceValue)
-						; Debug.TraceUser(sLog, theObject + " provides " + resourceRating + ", user is at " + resourceTotal + ", maxProduction = " + maxProduction)
 						if(resourceTotal + resourceRating <= maxProduction)
 							; WSFW 2.0.0 - Moving the call to ResourceObjects.Remove before the assign calls, that way TryToAssignResourceType can be called safely from with the assign functions. Currently the default function uses bResetMode = true to prevent that, but our chain of functions for nonWorkshopNPCScript functions doesn't have that flag (primarily because that flag is being used to do too many things and it makes the code unclear)
 							
-							; Debug.TraceUser(sLog, theObject + " is about to be assigned to " + theWorker + ", removing from array.")
 							;object is being assigned -> remove 
 							ResourceObjects.Remove(objectIndex)
 							
 							WorkshopNPCScript asWorkshopNPC = theWorker as WorkshopNPCScript
 							if(asWorkshopNPC)
-								; Debug.TraceUser(sLog, "Calling AssignActorToObjectV2 for " + theWorker + " to " + theObject)
 								AssignActorToObjectV2(asWorkshopNPC, theObject, bResetMode = true, bAddActorCheck = false, bUpdateObjectArray = false)
 							else
-								; Debug.TraceUser(sLog, "Calling WorkshopFunctions.AssignActorToObject for non-WorkshopNPCScript " + theWorker + " to " + theObject)
 								; WSFW 2.0.0 - Route regular actors to our centralized functions
 								WorkshopFramework:WorkshopFunctions.AssignActorToObject(theObject, theWorker, abAutoHandleAssignmentRules = true, abAutoUpdateActorStatus = true, abRecalculateWorkshopResources = false)
 							endif
@@ -3528,10 +3430,9 @@ function TryToAssignResourceType(WorkshopScript workshopRef, ActorValue resource
 							resourceTotal += resourceRating
 							WorkshopFramework:WorkshopFunctions.SetMultiResourceProduction(theWorker, resourceTotal)
 							
-							if(resourceTotal >= maxProduction)
-								; Debug.TraceUser(sLog, theWorker + " is fully assigned for resource with " + resourceTotal + ", maxProduction = " + maxProduction)
+							if(resourceTotal == maxProduction)
 								actorAssigned = true
-							endif
+							endif							
 						endif
 					endif
 					
@@ -4427,7 +4328,7 @@ endFunction
 function wsTrace(string traceString, int severity = 0, bool bNormalTraceAlso = false) DebugOnly
 	;UFO4P: Added line to re-open the log:
 	debug.OpenUserLog(UserLogName)
-	; Debug.TraceUser(userlogName, " " + traceString, severity)
+	debug.traceUser(userlogName, " " + traceString, severity)
 endFunction
 
 ; utility function to wait for edit lock
@@ -4978,18 +4879,10 @@ endFunction
 function WSFW_AddActorToWorkerArray(Actor actorRef, int resourceIndex)
 	if(actorRef)
 		if(resourceIndex == WorkshopRatingFood)
-			if(WSFW_FoodWorkers == None)
-				WSFW_FoodWorkers = new Actor[0]
-			endIf
-				
 			if(WSFW_FoodWorkers.Find(actorRef) < 0)
 				WSFW_FoodWorkers.Add(actorRef)
 			endif
 		elseif(resourceIndex == WorkshopRatingSafety)
-			if(WSFW_SafetyWorkers == None)
-				WSFW_SafetyWorkers = new Actor[0]
-			endIf
-				
 			if(WSFW_SafetyWorkers.Find(actorRef) < 0)
 				WSFW_SafetyWorkers.Add(actorRef)
 			endif


### PR DESCRIPTION
-Removed obsolete FixSettlerCount calls as this issue should no longer be a problem as of 2.0.2.
-Fixed a bug with the threaded version of ScrapObject which could result in the item not being correctly scrapped.
-Settlement Layout objects should no longer be created at the player’s feet, or in the workshop workbench.
-Fixed a bug that would prevent custom AssignActor functions from being called.
-Added Build Limit controls to the Manage settlement menu. (thank you pra!)
