### PR TITLE
2.0.7

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
@@ -171,7 +171,12 @@ Function UpdateDisplay()
 		if(bReverse && bReverseFlipsStacking)
 			Self.MoveTo(kControlledRef)
 		else
-			kControlledRef.MoveTo(Self)
+			if(kControlledRef.X != Self.X || kControlledRef.Y != Self.Y || kControlledRef.Z != Self.Z)
+				kControlledRef.MoveTo(Self)
+				
+				; Calling the OnRelease event code as a trigger those objects can react to the movement
+				kControlledRef.OnRelease()
+			endif
 		endif
 	endif
 	

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/RealInventoryDisplay.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/RealInventoryDisplay.psc
@@ -106,7 +106,12 @@ EndEvent
 ; -------------------------------
 
 WorkshopScript Function GetWorkshop()
-	return GetLinkedRef(GetWorkshopItemKeyword()) as WorkshopScript
+	WorkshopScript thisWorkshop = GetLinkedRef(GetWorkshopItemKeyword()) as WorkshopScript
+	if( ! thisWorkshop)
+		thisWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(Self)
+	endif
+	
+	return thisWorkshop
 EndFunction
 
 String Function GetVendorID()

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
@@ -342,7 +342,7 @@ Function RunCode()
 			
 				WorkshopObjectScript asWorkshopObject = kResult as WorkshopObjectScript
 				
-				if(bForceWorkshopItemLink || asWorkshopObject || kResult.GetValue(WorkshopResourceObject) > 0)
+				if(bForceWorkshopItemLink || asWorkshopObject || kResult.GetValue(WorkshopResourceObject) > 0 || (kResult as WorkshopFramework:ObjectRefs:RealInventoryDisplay))
 					kResult.SetLinkedRef(kWorkshopRef, WorkshopItemKeyword)
 				endif
 				

--- a/Scripts/Source/User/WorkshopFramework/WorkshopFunctions.psc.bak
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopFunctions.psc.bak
@@ -15,7 +15,7 @@ Scriptname WorkshopFramework:WorkshopFunctions Hidden Const
 
 import WorkshopDataScript
 import WorkshopFramework:Library:DataStructures
-import WorkshopFramework:Library:UtilityFunctions
+
 
 ; -----------------------------------
 ; Workshop Parent Replacements
@@ -617,8 +617,6 @@ Float Function GetMultiResourceProduction(Actor akActorRef) global
 	WorkshopNPCScript asWorkshopNPC = akActorRef as WorkshopNPCScript
 	
 	if(asWorkshopNPC)
-		;ModTrace("WorkshopFunctions.GetMultiResourceProduction called for actor " + akActorRef + " reporting " + asWorkshopNPC.multiResourceProduction)
-		
 		return asWorkshopNPC.multiResourceProduction
 	else
 		ActorValue MultiResourceProductionAV = GetMultiResourceProductionAV()
@@ -630,8 +628,6 @@ EndFunction
 
 Function SetMultiResourceProduction(Actor akActorRef, Float afValue) global
 	WorkshopNPCScript asWorkshopNPC = akActorRef as WorkshopNPCScript
-	
-	;ModTrace("WorkshopFunctions.SetMultiResourceProduction setting multiResourceProduction for actor " + akActorRef + " to " + afValue)
 	
 	if(asWorkshopNPC)
 		asWorkshopNPC.multiResourceProduction = afValue
@@ -1322,7 +1318,7 @@ Location Function MakePermanentNPCFullSettler(Actor akActorRef, Bool abCommandab
 		
 		ChosenLocation = (akActorRef as WorkshopNPCScript).OpenWorkshopSettlementMenu(WorkshopAssignHomePermanentActor)
 		
-		;ModTrace("[MakePermanentNPCFullSettler] WorkshopAssignHomePermanentActor = " + WorkshopAssignHomePermanentActor + ", player chose location: " + ChosenLocation)
+		WorkshopFramework:Library:UtilityFunctions.ModTrace("[MakePermanentNPCFullSettler] WorkshopAssignHomePermanentActor = " + WorkshopAssignHomePermanentActor + ", player chose location: " + ChosenLocation)
 	else
 		ChosenLocation = Game.GetPlayer().OpenWorkshopSettlementMenuEx(None)
 		


### PR DESCRIPTION
- Invisible Workshop Object scripts will now call the OnRelease event code on any objects they control when UpdateDisplay is called so that any spawned object can be scripted to react to the event.
- Fixed a bug that could cause an NPC to be assigned to food or defense objects in addition to their other assignment.
- Fixed a bug that could cause an NPC to be assigned to more and more food/defense objects each time the player returned to a settlement.
- Fixed a vanilla game bug where creature workshop NPCs that got into a “wander-loop” in their sandbox package could never break free when transferred to a different settlement, so they would stay in the previous one forever.