### PR TITLE
2.0.15

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Library/UtilityFunctions.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/UtilityFunctions.psc
@@ -1453,3 +1453,20 @@ String Function IntToHex( Int aiInt, Int aiPadDigits = 0 ) Global
 
 	Return lsResult
 EndFunction
+
+
+; ------------------------------
+; GetWorkshopWorldspace
+; 
+; Description: Return the worldspace record the settlement workshop is in
+;
+; Parameters:
+; WorkshopScript akWorkshopRef
+; ------------------------------
+WorldSpace Function GetWorkshopWorldspace(WorkshopScript akWorkshopRef) global
+    if(akWorkshopRef.isInInterior() && akWorkshopRef.myMapMarker)
+        return akWorkshopRef.myMapMarker.GetWorldspace()
+    endif
+
+    return akWorkshopRef.GetWorldspace()
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/SettlementLayoutManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/SettlementLayoutManager.psc
@@ -1424,8 +1424,10 @@ Function ExportSettlementLayout(String asExportFileName = "", WorkshopScript akW
 		kArgs = new Var[2]
 		kArgs[0] = akWorkshopRef
 		kArgs[1] = asExportFileName
-		; Calling export functions in parallel to reduce change the log will close before ExportLinkedItems has a chance to increment the iAwaitingExportCallbacks
+		; Calling export functions in parallel to reduce chance the log will close before ExportLinkedItems has a chance to increment the iAwaitingExportCallbacks
 		CallFunctionNoWait("ExportUnlinkedItems", kArgs)
+	else
+		Debug.MessageBox("IncludeVanillaScrapInfo disabled.")
 	endif
 	
 	int iThreadsStarted = ExportLinkedItems(akWorkshopRef, asExportFileName)
@@ -1541,7 +1543,7 @@ Int Function ExportUnlinkedItems(WorkshopScript akWorkshopRef, String asLogName)
 			ModTrace("[Export] Unlinked Item thread details: iAwaitingExportCallbacks (before prediction correction) = " + iAwaitingExportCallbacks + ", iPredictedThreads = " + iPredictedThreads + ", iActualThreads = " + iActualThreads)
 			iAwaitingExportCallbacks -= iPredictedThreads - iActualThreads
 	
-			ScrapFinderQuest.Stop()
+			;ScrapFinderQuest.Stop()
 		endif
 	endif
 	


### PR DESCRIPTION
- Fixed a bug with UIManager.ShowMessageSelectorMenuFormlistAndWait that would cause it to fail.
- UIManager.ShowMessageSelectorMenuAndWait and UIManager.ShowMessageSelectorMenuFormlistAndWait can now correctly accept ObjectReferences as the aMessageTitleNameHolder argument.
- Fixed a bug that could prevent a scrap profile from being collected properly during a Settlement Layout export.
- Fixed a bug when using UIManager’s barter menu system with object references.
- UIManager’s message and barter menu functions now have an extra parameter available, by using the new V2 or V3 versions of those functions, which will make UIManager hold the call to the function in a loop if another call is still being resolved. This acts as a sort of virtual queue so multiple requests can be made to the system before the previous one has finished, it will simply wait until the previous call is finished before presenting the menu to the player.
