### PR TITLE
2.0.16

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/LockableWorkshopObjectScript.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/LockableWorkshopObjectScript.psc
@@ -1,0 +1,197 @@
+; ---------------------------------------------
+; WorkshopFramework:Library:ObjectRefs:LockableWorkshopObjectScript.psc - by E
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:Library:ObjectRefs:LockableWorkshopObjectScript extends WorkshopObjectScript
+
+import WorkshopFramework:Library:UtilityFunctions
+
+; -----------------------------------------
+; Consts
+; -----------------------------------------
+
+Int Property GENERICLOCK_LOCK_INVALID = -2 AutoReadOnly Hidden
+Int Property GENERICLOCK_KEY_INVALID = -1 AutoReadOnly Hidden
+Int Property GENERICLOCK_KEY_NONE = 0 AutoReadOnly Hidden
+
+; Keys will reset back to the first one when the last one is reached.
+; The key returned is semi-unique is never generated until the lock can be aquired.
+; If there are more than 1K keys being requested, You're Doing It Wrong(tm)
+Int INTERNAL_GENERICLOCK_KEY_FIRST = 1024 Const
+Int INTERNAL_GENERICLOCK_KEY_LAST = 2047 Const
+
+
+; -----------------------------------------
+; Vars
+; -----------------------------------------
+
+Bool bGenericLock_Initialized = False
+Int iGenericLock_CurrentKey
+Int iGenericLock_NextKey
+Int iGenericLock_LockCount
+
+
+
+; -----------------------------------------
+; Public API
+; Anyone wanting the lock should use these functions.
+; These should be thread-safe (that's the point, right?) and
+; if used correctly can be used to serialize resources.
+; -----------------------------------------
+
+	; Get/Release Lock Return values:
+	; <0 = Unable to [un]lock
+	;  0 = Unlocked
+	; 1+ = Current lock key
+	
+Int Function GetLock( Int aiKey = 0, Bool abWaitForLock = True )
+    ; Create lock as needed
+    If( ! bGenericLock_Initialized )
+        INTERNAL_GenericLock_Init()
+    EndIf
+    
+    ; Valid key to relock with?
+    If(( aiKey != GENERICLOCK_KEY_NONE ) && \
+		( ( aiKey < INTERNAL_GENERICLOCK_KEY_FIRST ) || ( aiKey > INTERNAL_GENERICLOCK_KEY_LAST ) ))
+     
+		Return GENERICLOCK_KEY_INVALID
+    EndIf
+    
+    ; Already locked?
+    If(( iGenericLock_CurrentKey != GENERICLOCK_KEY_NONE ) && \
+		( iGenericLock_CurrentKey == aiKey ))
+		
+        ; With the proper key, it's ok
+        iGenericLock_LockCount += 1
+        Return aiKey
+    EndIf
+    
+    ; Wait for lock to be unlocked
+    While( IsLockHeld )
+        
+        If( ! abWaitForLock )
+            ; On second thought, don't wait, just return it's already locked
+            Return GENERICLOCK_KEY_INVALID
+        EndIf
+        
+        Utility.Wait( 0.1 )
+    EndWhile
+    
+    ; Lock it with the new key
+    iGenericLock_CurrentKey = INTERNAL_GenericLock_GetNextKey
+    iGenericLock_LockCount = 1
+    EXTERNAL_GenericLock_GetLock()
+    
+    ; Locked
+    Return iGenericLock_CurrentKey
+EndFunction
+
+
+Int Function ReleaseLock( Int aiKey )
+    ; Valid lock?
+    If( ! bGenericLock_Initialized )
+        INTERNAL_GenericLock_Init()
+    EndIf
+    
+    ; Validate caller
+    If( iGenericLock_CurrentKey == GENERICLOCK_KEY_NONE )
+        Return GENERICLOCK_KEY_NONE
+    EndIf
+	
+    If( aiKey != iGenericLock_CurrentKey )
+        Return GENERICLOCK_KEY_INVALID
+    EndIf
+    
+    ; Release the lock
+    iGenericLock_LockCount -= 1
+    If( iGenericLock_LockCount < 1 )
+        EXTERNAL_GenericLock_ReleaseLock()
+        iGenericLock_LockCount = 0
+        iGenericLock_CurrentKey = GENERICLOCK_KEY_NONE
+    EndIf
+    
+    ; GENERICLOCK_KEY_NONE when unlocked, key if still locked
+    Return iGenericLock_CurrentKey
+EndFunction
+
+
+Int Function GetQueueCount()
+	return iGenericLock_LockCount
+EndFunction
+
+
+Function ForceClearLock()
+	; This should really only be used in an emergency situation - for example, after terminating scripts with the Save Editor and needing to restore the lock system to functioning again
+	EXTERNAL_GenericLock_ReleaseLock()
+    iGenericLock_LockCount = 0
+    iGenericLock_CurrentKey = GENERICLOCK_KEY_NONE	
+EndFunction
+
+
+Bool Property IsLockHeld
+    Bool Function Get()
+        If( iGenericLock_CurrentKey != GENERICLOCK_KEY_NONE )
+            Return True
+        EndIf
+        Return EXTERNAL_GenericLock_GetLocked()
+    EndFunction
+EndProperty
+
+; Internal API
+; This is not a public API - These are used internally
+; ----------------------------------------
+
+
+Function INTERNAL_GenericLock_Init()
+    iGenericLock_CurrentKey         = 0
+    iGenericLock_NextKey            = INTERNAL_GENERICLOCK_KEY_FIRST
+    iGenericLock_LockCount          = 0
+    bGenericLock_Initialized        = True
+EndFunction
+
+
+Int Property INTERNAL_GenericLock_GetNextKey
+    Int Function Get()
+        Int nextKey = iGenericLock_NextKey
+        
+        iGenericLock_NextKey += 1
+        If( iGenericLock_NextKey < INTERNAL_GENERICLOCK_KEY_FIRST )||( iGenericLock_NextKey > INTERNAL_GENERICLOCK_KEY_LAST )
+            iGenericLock_NextKey = INTERNAL_GENERICLOCK_KEY_FIRST
+        EndIf
+        
+        Return nextKey
+    EndFunction
+EndProperty
+
+
+
+
+; External API
+; This is not a public API - There are used internally by ESM:GenericLock
+; Inheritors need to implement these if they need additional functionality
+; ----------------------------------------
+
+
+Bool Function EXTERNAL_GenericLock_GetLocked()
+    ; STUB:  Override this with any additional conditions
+    Return False
+EndFunction
+
+
+Function EXTERNAL_GenericLock_GetLock()
+    ; STUB:  Override this with any additional changes
+EndFunction
+
+
+Function EXTERNAL_GenericLock_ReleaseLock()
+    ; STUB:  Override this with any additional changes
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/ProtectedWorkshopObjectScript.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/ProtectedWorkshopObjectScript.psc
@@ -1,0 +1,45 @@
+; ---------------------------------------------
+; WorkshopFramework:Library:ObjectRefs:ProtectedWorkshopObjectScript.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:Library:ObjectRefs:ProtectedWorkshopObjectScript extends WorkshopFramework:Library:ObjectRefs:LockableWorkshopObjectScript
+
+Bool bAllowDisable = false
+Bool bAllowDelete = false
+
+Function AllowDisable()
+	bAllowDisable = true
+EndFunction
+
+Function AllowDelete()
+	bAllowDelete = true
+EndFunction
+
+Function Disable(Bool abFade = false)
+	if( ! bAllowDisable)
+		; Do nothing - overriding vanilla behaviort to avoid these being destroyed
+		
+		return
+	endif
+	
+	Parent.Disable(abFade)
+EndFunction
+
+Function Delete()
+	if( ! bAllowDelete)
+		; Do nothing - overriding vanilla behaviort to avoid these being destroyed
+		
+		return
+	endif
+	
+	Parent.Delete()
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/Task.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/Task.psc
@@ -80,7 +80,7 @@ Function StartTask()
 	if(bFirstIterationImmediate)
 		RunCode()
 		
-		if(iIterations >= iTotalIterations)
+		if(iTotalIterations > 0 && iIterations >= iTotalIterations)
 			Complete()
 			
 			return
@@ -99,7 +99,7 @@ Function RunCode()
 		
 		iIterations += 1
 		
-		if(iIterations >= iTotalIterations)
+		if(iTotalIterations > 0 && iIterations >= iTotalIterations)
 			Complete()
 			bCompleted = true
 		endif

--- a/Scripts/Source/User/WorkshopFramework/NPCManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/NPCManager.psc
@@ -890,6 +890,11 @@ Function RemoveNPCFromWorkshop(Actor akActorRef, WorkshopScript akWorkshopRef = 
 	
 	if( ! abNPCTransfer)
 		; Completely removed from workshop system
+		if(akWorkshopRef.SettlementOwnershipFaction && akWorkshopRef.UseOwnershipFaction)
+			akActorRef.SetCrimeFaction(None)
+			akActorRef.SetFactionOwner(None)
+		endif
+		
 		WorkshopParent.WorkshopActorApply.RemoveFromRef(akActorRef)
 		WorkshopParent.PermanentActorAliases.RemoveRef(akActorRef)
 		RemoveAliasData(akActorRef)

--- a/Scripts/Source/User/WorkshopFramework/Quests/FetchLocationData.psc
+++ b/Scripts/Source/User/WorkshopFramework/Quests/FetchLocationData.psc
@@ -11,15 +11,10 @@
 ; N/A
 ; ---------------------------------------------
 
-Scriptname WorkshopFramework:Quests:FetchLocationData extends Quest
+Scriptname WorkshopFramework:Quests:FetchLocationData extends WorkshopFramework:Library:StoryEventQuest
 
 Group Aliases
 	LocationAlias Property RequestedLocation Auto Const Mandatory
 	ReferenceAlias Property MapMarker Auto Const Mandatory
+	ReferenceAlias Property CenterMarker Auto Const Mandatory
 EndGroup
-
-int Property iReserveID = -1 Auto Hidden
-
-Event OnStoryScript(Keyword akKeyword, Location akLocation, ObjectReference akRef1, ObjectReference akRef2, int aiValue1, int aiValue2)
-	iReserveID = aiValue1
-EndEvent

--- a/Scripts/Source/User/WorkshopFramework/WSFW_API.psc
+++ b/Scripts/Source/User/WorkshopFramework/WSFW_API.psc
@@ -447,30 +447,50 @@ EndFunction
 
 
 ; ------------------------------
-; GetDefaultPlaceObjectsBatchAV
+; GetMapMarker
 ;
 ; Description: Grabs the map marker from a location
 ; ------------------------------
 ObjectReference Function GetMapMarker(Location akLocation) global
 	WorkshopFramework:WSFW_APIQuest API = GetAPI()
 	
-	int iReserveID = Utility.RandomInt(1, 999999)
-	if(API.EventKeyword_FetchLocationData.SendStoryEventAndWait(akLocation, aiValue1 = iReserveID))
-		Utility.Wait(0.1) ; Give the event quest a moment to set the reserve ID
+	WorkshopFramework:Library:StoryEventQuest SEQ = API.StoryEventManager.WSFW_API_SendStoryEvent(API.EventKeyword_FetchLocationData, plocLocation = akLocation, pfltTimeout = 5.0)
+	
+	if(SEQ != None)
+		WorkshopFramework:Quests:FetchLocationData SEQControllerLocFinder = SEQ as WorkshopFramework:Quests:FetchLocationData
 		
-		WorkshopFramework:Quests:FetchLocationData[] FetchLocationDataQuests = API.FetchLocationDataQuests
-		int i = 0
-		while(i < FetchLocationDataQuests.Length)
-			if(FetchLocationDataQuests[i].IsRunning() && FetchLocationDataQuests[i].iReserveID == iReserveID)
-				ObjectReference kMapMarkerRef = FetchLocationDataQuests[i].MapMarker.GetRef()
-				
-				FetchLocationDataQuests[i].Stop()
-				
-				return kMapMarkerRef
-			endif
-			
-			i += 1
-		endWhile
+		ObjectReference kMapMarkerRef = SEQControllerLocFinder.MapMarker.GetRef()
+
+		SEQ.Dispose()
+		
+		return kMapMarkerRef
+	endif
+	
+	return None
+EndFunction
+
+; ------------------------------
+; GetLocationCenter
+;
+; Description: Grabs the map marker from a location
+; ------------------------------
+ObjectReference Function GetLocationCenter(Location akLocation, Bool abGetMapMarkerIfCenterNotFound = false) global
+	WorkshopFramework:WSFW_APIQuest API = GetAPI()
+	
+	WorkshopFramework:Library:StoryEventQuest SEQ = API.StoryEventManager.WSFW_API_SendStoryEvent(API.EventKeyword_FetchLocationData, plocLocation = akLocation, pfltTimeout = 5.0)
+	
+	if(SEQ != None)
+		WorkshopFramework:Quests:FetchLocationData SEQControllerLocFinder = SEQ as WorkshopFramework:Quests:FetchLocationData
+		
+		ObjectReference kCenterMarkerRef = SEQControllerLocFinder.CenterMarker.GetRef()
+		
+		if(kCenterMarkerRef == None && abGetMapMarkerIfCenterNotFound)
+			kCenterMarkerRef = SEQControllerLocFinder.MapMarker.GetRef()
+		endif
+		
+		SEQ.Dispose()
+		
+		return kCenterMarkerRef
 	endif
 	
 	return None

--- a/Scripts/Source/User/WorkshopFramework/WSFW_APIQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/WSFW_APIQuest.psc
@@ -30,7 +30,9 @@ Group Controllers
 	{ 1.0.8 }
 	WorkshopFramework:F4SEManager Property F4SEManager Auto Const Mandatory
 	WorkshopFramework:HUDFrameworkManager Property HUDFrameworkManager Auto Const Mandatory
-	WorkshopFramework:Quests:FetchLocationData[] Property FetchLocationDataQuests Auto Const Mandatory
+	
+	WorkshopFramework:Quests:StoryEventManager Property StoryEventManager Auto Const Mandatory
+	{ 2.0.16 }
 EndGroup
 
 

--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -1254,7 +1254,10 @@ endEvent
 
 
 function InitializeLocation(WorkshopScript workshopRef, RefCollectionAlias SettlementNPCs, ReferenceAlias theLeader, ReferenceAlias theMapMarker)
-	workshopRef.myMapMarker = theMapMarker.GetRef()
+	if(theMapMarker.GetRef() != None)
+		; 2.0.16 
+		workshopRef.myMapMarker = theMapMarker.GetRef()
+	endif
 
 	; force recalc (unloaded workshop)
 	workshopRef.RecalculateWorkshopResources(true)
@@ -2913,6 +2916,12 @@ function UnassignActor_PrivateV2(WorkshopNPCScript theActor, bool bRemoveFromWor
 			WorkshopActorApply.RemoveFromRef (theActor)
 			PermanentActorAliases.RemoveRef (theActor)
 			theActor.SetValue(WorkshopPlayerOwnership, 0)
+			
+			; Clear settlement faction stuff
+			if(workshopRef.SettlementOwnershipFaction && workshopRef.UseOwnershipFaction)
+				theActor.SetCrimeFaction(None)
+				theActor.SetFactionOwner(None)
+			endif
 		endif
 
 		; PATCH - remove workshop ID as well

--- a/Scripts/Source/User/WorkshopScript.psc
+++ b/Scripts/Source/User/WorkshopScript.psc
@@ -17,8 +17,8 @@ Location Property myLocation Auto Hidden
 {workshop's location (filled onInit)
  this is a property so the WorkshopParent script can access it}
 
-ObjectReference Property myMapMarker auto hidden
-{workshop's map marker (filled by WorkshopParent.InitializeLocation) }
+ObjectReference Property myMapMarker auto
+{ workshop's map marker (filled by WorkshopParent.InitializeLocation) - or you can fill it manually here }
 
 Group Optional
 	Faction Property SettlementOwnershipFaction auto


### PR DESCRIPTION
- NPCs that are completely removed as settlers should no longer be flagged as part of that settlement’s faction. This should prevent an issue where NPCs that turn on the player, such as some main quest companions, will no longer aggro the entire settlement - so long as the NPC is correctly removed from the settlement first.
- myMapMarker property on WorkshopScript is now exposed so it can be set in the CK. -- This will allow for filling it for settlement’s where the game fails to find the marker on its own, which can happen with certain settlement configurations.
- WorkshopParent will no longer overwrite the myMapMarker property on workshop’s if the game failed to find the map marker.
- Updated FetchLocationData quests, which were used for some API functions, to use the StoryEventQuest management system that was added several patches ago.
- Added new API function: GetLocationCenter which accepts a location, and an optional boolean to accept the map marker if the location center could not be found. This will return the reference for a location with the LocationCenterMarker RefType.