### PR TITLE
2.0.17

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/AssaultSettlement.psc
+++ b/Scripts/Source/User/WorkshopFramework/AssaultSettlement.psc
@@ -690,6 +690,8 @@ Function SetupAssault()
 				RegisterForRemoteEvent(thisLocation, "OnLocationLoaded")
 			endif
 		else
+			CleanupAssault()
+			
 			Stop()
 		endif		
 	endif

--- a/Scripts/Source/User/WorkshopFramework/Fragments/Terminals/TERM_WSFW_Tools_Power_menu_0102CE8C.psc
+++ b/Scripts/Source/User/WorkshopFramework/Fragments/Terminals/TERM_WSFW_Tools_Power_menu_0102CE8C.psc
@@ -1,0 +1,62 @@
+;BEGIN FRAGMENT CODE - Do not edit anything between this and the end comment
+Scriptname WorkshopFramework:Fragments:Terminals:TERM_WSFW_Tools_Power_menu_0102CE8C Extends Terminal Hidden Const
+
+;BEGIN FRAGMENT Fragment_Terminal_01
+Function Fragment_Terminal_01(ObjectReference akTerminalRef)
+;BEGIN CODE
+int iConfirm = WSFW_PowerGridDestroyConfirm.Show()
+
+if(iConfirm == 1)
+   Bool bSuccess = F4SEManager.WSFWID_ResetPowerGrid(None)
+
+  WSFW_PowerGridFixDestroyComplete.Show()
+endif
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_02
+Function Fragment_Terminal_02(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_PowerGridScanStarted.Show()
+
+Bool bSuccess = F4SEManager.WSFWID_ScanPowerGrid(akWorkshopRef = None)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_03
+Function Fragment_Terminal_03(ObjectReference akTerminalRef)
+;BEGIN CODE
+WorkshopObjectManager.ForcePowerTransmission(None)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_04
+Function Fragment_Terminal_04(ObjectReference akTerminalRef)
+;BEGIN CODE
+Bool bSuccess = F4SEManager.WSFWID_CheckAndFixPowerGrid(akWorkshopRef = None, abFixAndScan = true, abResetIfFixFails = false)
+
+if(bSuccess)
+RepairResultsMessage.Show()
+else
+RepairFailMessage.Show()
+endif
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;END FRAGMENT CODE - Do not edit anything between this and the begin comment
+
+WorkshopFramework:WorkshopObjectManager Property WorkshopObjectManager Auto Const Mandatory
+WorkshopFramework:F4SEManager Property F4SEManager Auto Const Mandatory
+Message Property RepairResultsMessage Auto Const Mandatory
+
+Message Property RepairFailMessage Auto Const Mandatory
+
+Message Property WSFW_PowerGridDestroyConfirm Auto Const Mandatory
+
+Message Property WSFW_PowerGridFixDestroyComplete Auto Const Mandatory
+
+Message Property WSFW_PowerGridScanStarted Auto Const Mandatory

--- a/Scripts/Source/User/WorkshopFramework/Fragments/Terminals/TERM__WSFWFrameworkControls0101607B.psc
+++ b/Scripts/Source/User/WorkshopFramework/Fragments/Terminals/TERM__WSFWFrameworkControls0101607B.psc
@@ -129,6 +129,54 @@ WSFW_Setting_Import_F4SEPower.SetValueInt(1)
 EndFunction
 ;END FRAGMENT
 
+;BEGIN FRAGMENT Fragment_Terminal_17
+Function Fragment_Terminal_17(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_Setting_AutomaticallyUnhideInvisibleWorkshopObjects.SetValueInt(0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_18
+Function Fragment_Terminal_18(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_Setting_AutomaticallyUnhideInvisibleWorkshopObjects.SetValueInt(1)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_19
+Function Fragment_Terminal_19(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_Setting_AutoRepairPowerGrids.SetValueInt(0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_20
+Function Fragment_Terminal_20(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_Setting_AutoRepairPowerGrids.SetValueInt(1)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_21
+Function Fragment_Terminal_21(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_Setting_AutoResetCorruptPowerGrid.SetValueInt(0)
+;END CODE
+EndFunction
+;END FRAGMENT
+
+;BEGIN FRAGMENT Fragment_Terminal_22
+Function Fragment_Terminal_22(ObjectReference akTerminalRef)
+;BEGIN CODE
+WSFW_Setting_AutoResetCorruptPowerGrid.SetValueInt(1)
+;END CODE
+EndFunction
+;END FRAGMENT
+
 ;END FRAGMENT CODE - Do not edit anything between this and the begin comment
 
 GlobalVariable Property WSFW_AlternateActivation_Workshop Auto Const Mandatory
@@ -148,3 +196,9 @@ GlobalVariable Property WSFW_Setting_Import_SpawnNPCs Auto Const Mandatory
 GlobalVariable Property WSFW_Setting_Import_SpawnPowerArmor Auto Const Mandatory
 
 GlobalVariable Property WSFW_Setting_Import_F4SEPower Auto Const Mandatory
+
+GlobalVariable Property WSFW_Setting_AutomaticallyUnhideInvisibleWorkshopObjects Auto Const Mandatory
+
+GlobalVariable Property WSFW_Setting_AutoRepairPowerGrids Auto Const Mandatory
+
+GlobalVariable Property WSFW_Setting_AutoResetCorruptPowerGrid Auto Const Mandatory

--- a/Scripts/Source/User/WorkshopFramework/Library/MasterQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/MasterQuest.psc
@@ -207,6 +207,7 @@ Function TriggerLocationChange()
 			sCastAs = "WorkshopFramework:Library:SlaveQuest"
 		endif
 		
+		ModTrace("[" + Self + "] TriggerLocationChange called on " + thisQuest)
 		Var[] kArgs = new Var[2]
 		kArgs[0] = EVENTSTAGE_FromMasterQuest
 		kArgs[1] = EVENTSTAGEITEM_PlayerChangedLocation

--- a/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/WorkshopAVReacting.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ObjectRefs/WorkshopAVReacting.psc
@@ -1,0 +1,32 @@
+Scriptname WorkshopFramework:Library:ObjectRefs:WorkshopAVReacting extends ObjectReference Const
+
+import WorkshopFramework:Library:DataStructures
+import WorkshopFramework:Library:UtilityFunctions
+import WorkshopFramework:WorkshopFunctions
+
+
+ActorValueSet[] Property ActiveThresholds Auto Const Mandatory
+{ If all these evaluate to true, this object will be enabled, otherwise disabled }
+
+Event OnCellLoad()
+	Keyword WorkshopItemKeyword = GetWorkshopItemKeyword()
+	
+	WorkshopScript thisWorkshop = GetLinkedRef(WorkshopItemKeyword) as WorkshopScript
+	if(thisWorkshop)
+		int i = 0
+		bool bEnable = true
+		while(i < ActiveThresholds.Length && bEnable)
+			if( ! CheckActorValueSet(thisWorkshop, ActiveThresholds[i]))
+				bEnable = false
+			endif
+			
+			i += 1
+		endWhile
+		
+		if(bEnable)
+			Self.Enable()
+		else
+			Self.Disable()
+		endif
+	endif
+EndEvent

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_ExportObjectData.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_ExportObjectData.psc
@@ -141,7 +141,7 @@ Function RunCode()
 	String sObjectName = F4SEManager.GetFormName(BaseForm)
 	if(sObjectName == "")
 		; Try and grab from ref instead
-		sObjectName = F4SEManager.GetReferenceName(kObjectRef)
+		sObjectName = F4SEManager.WSFWID_GetReferenceName(kObjectRef)
 	endif
 	
 	Bool bIsResourceObject = false

--- a/Scripts/Source/User/WorkshopFramework/SettlementLayoutManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/SettlementLayoutManager.psc
@@ -335,6 +335,16 @@ Function HandleGameLoaded()
 EndFunction
 
 Function HandleInstallModChanges()
+	if(iInstalledVersion < 45)
+		; At some point scrap finders weren't being disabled after an export of the scrap profile, fixed in this version, but we need to one-time shut them all down to ensure they can run again
+		int i = 0
+		while(i < ScrapFinders.Length)
+			ScrapFinders[i].Stop()
+			
+			i += 1
+		endWhile
+	endif
+
 	if(iInstalledVersion < 27)
 		; This check was failing in patch 26 (1.2.0), because F4SEManager was not correctly flagging before this quest initialized
 		if(F4SEManager.IsF4SERunning)
@@ -1543,7 +1553,7 @@ Int Function ExportUnlinkedItems(WorkshopScript akWorkshopRef, String asLogName)
 			ModTrace("[Export] Unlinked Item thread details: iAwaitingExportCallbacks (before prediction correction) = " + iAwaitingExportCallbacks + ", iPredictedThreads = " + iPredictedThreads + ", iActualThreads = " + iActualThreads)
 			iAwaitingExportCallbacks -= iPredictedThreads - iActualThreads
 	
-			;ScrapFinderQuest.Stop()
+			ScrapFinderQuest.Stop()
 		endif
 	endif
 	

--- a/Scripts/Source/User/WorkshopFramework/UIManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/UIManager.psc
@@ -785,6 +785,9 @@ Function PreparePhantomVendor(Form afBarterDisplayNameForm, Keyword[] aFilterKey
 	Actor kPhantomVendorRef = PhantomVendorAlias.GetReference() as Actor
 	ObjectReference kPhantomVendorContainerRef = PhantomVendorContainerAlias.GetRef()
 	
+	; Clear out the filter list
+	PhantomVendorBuySellList.Revert()
+	
 	; Remove items from the vendor's pockets - they shouldn't have anything, but just in case
 	kPhantomVendorRef.RemoveAllItems()
 	

--- a/Scripts/Source/User/WorkshopFramework/WorkshopFunctions.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopFunctions.psc
@@ -1435,6 +1435,60 @@ WorkshopScript Function GetNearestWorkshop(ObjectReference akToRef) global
 	return nearestWorkshop
 EndFunction
 
+; -----------------------------------
+; GetSettlementWorkshopFromLocation
+;
+; Description: Global function to lookup a settlement workbench from a location
+;
+; Parameters: aLocation 
+; -----------------------------------
+
+WorkshopScript Function GetSettlementWorkshopFromLocation(Location aLocation) global
+	if(aLocation == None)
+		return None
+	endIf
+	
+	WorkshopParentScript WorkshopParent = GetWorkshopParent()
+	return WorkshopParent.GetWorkshopFromLocation(aLocation)
+endFunction
+
+
+; -----------------------------------
+; OpenKeywordFilteredWorkshopSettlementMenuEx
+;
+; Description: Global function to relay calls to OpenWorkshopSettlementMenuEx and place Keywords in formlists for the sake of filtering.
+;
+; Parameters are the same as vanilla OpenWorkshopSettlementMenuEx, except that FormList akIncludeKeywordList and FormList akExcludeKeywordList have been replaced by Keyword arrays, and since that function is generally run on a ref the paramter akRunOn determines what the function is run on - if nothing is sent, the player is used.
+; -----------------------------------
+
+Location Function OpenKeywordFilteredWorkshopSettlementMenuEx(Keyword akActionKW, Message astrConfirm = none, Location aLocToHighlight = none, Keyword[] akIncludeFilterKeywords = none, Keyword[] akExcludeFilterKeywords = none,  bool abExcludeZeroPopulation = false, bool abOnlyOwnedWorkshops= true, bool abTurnOffHeader= false, bool abOnlyPotentialVassalSettlements= false, bool abDisableReservedByQuests = false, ObjectReference akRunOn = None) global
+	Formlist IncludeKeywordList = Game.GetFormFromFile(0x0002E55E, "WorkshopFramework.esm") as Formlist
+	Formlist ExcludeKeywordList = Game.GetFormFromFile(0x0002E55D, "WorkshopFramework.esm") as Formlist
+	
+	IncludeKeywordList.Revert()
+	int i = 0
+	while(i < akIncludeFilterKeywords.Length)
+		IncludeKeywordList.AddForm(akIncludeFilterKeywords[i])
+		
+		i += 1
+	endWhile
+	
+	ExcludeKeywordList.Revert()
+	i = 0
+	while(i < akExcludeFilterKeywords.Length)
+		ExcludeKeywordList.AddForm(akExcludeFilterKeywords[i])
+		
+		i += 1
+	endWhile
+	
+	if(akRunOn == None)
+		akRunOn = Game.GetPlayer()
+	endIf
+	
+	; Can we dynamically populate a list for use with OpenWorkshopSettlementMenuEx? I vaguely recall that we can't from tests with Conqueror
+	return akRunOn.OpenWorkshopSettlementMenuEx(akActionKW, astrConfirm, aLocToHighlight, IncludeKeywordList, ExcludeKeywordList, abExcludeZeroPopulation, abOnlyOwnedWorkshops, abTurnOffHeader, abOnlyPotentialVassalSettlements, abDisableReservedByQuests)	
+EndFunction
+
 
 ; -----------------------------------
 ; GetSettlements

--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -2711,9 +2711,10 @@ function AddActorToWorkshop(WorkshopNPCScript assignedActor, WorkshopScript work
 	
 	if( ! bResetMode && ! bAlreadyAssigned)
 		; WSFW 2.0.3 - Previously, this event was only being fired for unique actors which made it far less useful
-		Var[] kargs = new Var[2]
+		Var[] kargs = new Var[3]
 		kargs[0] = assignedActor
 		kargs[1] = newWorkshopID
+		kargs[2] = oldWorkshopID ; WSFW 2.0.17
 		SendCustomEvent("WorkshopAddActor", kargs)
 	endif
 endFunction
@@ -4462,6 +4463,7 @@ endFunction
 ; utility function to wait for edit lock
 ; increase wait time while more threads are in here
 int editLockCount = 1
+int iMaxLockWaitCount = 100 Const
 function GetEditLock()
 	editLockCount += 1
 	
@@ -4469,8 +4471,16 @@ function GetEditLock()
 		StartTimer (1.0, UFO4P_ThreadMonitorTimerID)
 	endif
 	
+	int iWaitCount = 0
 	while(EditLock)
-		utility.wait(0.1 * editLockCount)
+		iWaitCount += 1
+		
+		; 2.0.17 - Adding simple permalock prevention for users without UFO4P installed
+		if(iWaitCount > iMaxLockWaitCount && UFO4P_ThreadMonitorRef == None)
+			UFO4P_ReleaseLock()
+		else
+			utility.wait(0.1 * editLockCount)
+		endif		
 	endWhile
 	
 	EditLock = true


### PR DESCRIPTION
- Added LockableWorkshopObjectScript and ProtectedWorkshopObjectScript to the WSFW library of scripts. The former allows for a workshopobjectscript that has locking functions to help prevent race conditions, the latter extends the former and protects the form from deletion by other scripts.
- Fixed a bug in UIManager.ShowFormlistBarterSelectMenuV3 that would cause all unselected items to be returned to the player instead of disposing them.
- Added RestartTimer functionality to the task system, this can also be used to change the time on a timer.
- Extended the set of Filter by Keyword function set by adding FilterByKeywordArray variations that will filter by a match of one or all keywords in the array depending on the abAnyMatch parameter.
- Added UnregisterMenu function to WorkshopMenuManager, which will safely remove a registered entry to the workshop menus.
- [F4SE Users] Workshop Framework now has code to repair/reset the power grid.
-- By default, WSFW automatically repairs/resets corrupt power power grids when entering a settlement. These options can be turned off in MCM or the Workshop Framework Controls holotape.
-- Note that when a power grid is repaired or reset, it will prevent the game from crashing due to corrupt power grid nodes, but some of those grids will need to be refreshed to make the power work again visually - such as lights being on. To do this, either rewire something on the grid, or pick up an item in the grid and put it down again.
- [F4SE Users] MCM and the Workshop Framework Controls holotape have a new section under Tools: Power Grid Tools. This offers four options:
-- Repair Power Grid: This will analyze the local power grid and attempt to remove any invalid nodes so that the power grid functions once more.
-- Reset Power Grid: This removes the local power grid, ensuring all corruptions are eliminated.
-- Scan Power Grid: This will dump the details of the power grid to wsfw_identifier log inside of the Documents\My Games\Fallout4\F4SE\ folder.
-- Force Transmit Power: This will attempt to cause all power involved items to transfer power, triggering animations - this can be useful after running a layout or Sim Settlements City Plan where some of the items failed to power up correctly.
MCM and the Workshop Framework Controls holotape now have an option to disable auto-showing invisible objects.
-Fixed a bug that could cause settlement layouts placement and exporting to stop working after several exports were done in a single save.