### PR TITLE
2.0.18

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/F4SEManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/F4SEManager.psc
@@ -243,7 +243,9 @@ Bool Function WSFWID_CheckAndFixPowerGrid(WorkshopScript akWorkshopRef = None, B
 	if(abFixAndScan) ; Should be fixed
 		Results = CheckAndFixPowerGrid(akWorkshopRef, 0) ; Scan again - should be clean
 		
+		ModTrace("abFixAndScan == true, Rescan with iFix == 0: " + akWorkshopRef + " results: " + Results)
 		if(abResetIfFixFails && Results.broken)
+			ModTrace("Corrupt power grid detected, calling WSFWID_ResetPowerGrid on " + akWorkshopRef + ".")
 			WSFWID_ResetPowerGrid(akWorkshopRef)
 		endif
 	endif

--- a/Scripts/Source/User/WorkshopFramework/InjectionManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/InjectionManager.psc
@@ -77,6 +77,7 @@ EndGroup
 Group InjectableRecords
 	InjectableActorMap[] Property InjectableLeveledActors Auto Const
 	InjectableItemMap[] Property InjectableLeveledItems Auto Const
+	; 2.0.18 - Note that we cleared out all the default inject formlists for the shops, as we were never actually using the WSFW_InjectableItemHolder leveled lists to replace the vanilla ones. This system has now been overhauled and instead an extra container for each vendor/level is spawned at the settlement, and when the player loads into it, those items are moved into the actual workshop vendor container. In addition, we switched these InjectableItemHolder LLs for the shops to Use All. We may need to do make all of these changes to all of the WSFW_InjectableItemHolder LLs.
 EndGroup
 
 

--- a/Scripts/Source/User/WorkshopFramework/Library/ControllerQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/ControllerQuest.psc
@@ -52,6 +52,7 @@ EndEvent
 
 
 Event Actor.OnPlayerLoadGame(Actor akActorRef)  
+	;Debug.Trace(Self + " OnPlayerLoadGame called.")
 	; Run GameLoaded code
 	GameLoaded()
 EndEvent

--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -95,6 +95,16 @@ Int Property iSaveFileMonitor Auto Hidden ; Important - only meant to be edited 
 ; Events
 ; ---------------------------------------------
 
+Event ObjectReference.OnCellLoad(ObjectReference akSender)
+	WorkshopScript thisWorkshop = akSender as WorkshopScript
+	
+	UnregisterForRemoteEvent(akSender, "OnCellLoad")
+	
+	if(F4SEManager.IsF4SERunning && Setting_AutoRepairPowerGrids.GetValueInt() == 1)
+		F4SEManager.WSFWID_CheckAndFixPowerGrid(thisWorkshop, abFixAndScan = true, abResetIfFixFails = Setting_AutoResetCorruptPowerGrid.GetValueInt() as Bool)
+	endif
+EndEvent
+
 ; Extending to fire off settlement enter/exit events
 Event OnTimer(Int aiTimerID)
 	Parent.OnTimer(aiTimerID)
@@ -112,7 +122,11 @@ Event OnTimer(Int aiTimerID)
 				currentWorkshop = WorkshopParent.GetWorkshopFromLocation(PlayerRef.GetCurrentLocation())
 				
 				if(F4SEManager.IsF4SERunning && Setting_AutoRepairPowerGrids.GetValueInt() == 1)
-					F4SEManager.WSFWID_CheckAndFixPowerGrid(currentWorkshop, abFixAndScan = true, abResetIfFixFails = Setting_AutoResetCorruptPowerGrid.GetValueInt() as Bool)
+					if(currentWorkshop.GetParentCell().IsLoaded())
+						F4SEManager.WSFWID_CheckAndFixPowerGrid(currentWorkshop, abFixAndScan = true, abResetIfFixFails = Setting_AutoResetCorruptPowerGrid.GetValueInt() as Bool)
+					else
+						RegisterForRemoteEvent(currentWorkshop, "OnCellLoad")
+					endif
 				endif
 			endif
 		endif

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/MoveContainerItemsOnLoad.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/MoveContainerItemsOnLoad.psc
@@ -1,0 +1,27 @@
+Scriptname WorkshopFramework:ObjectRefs:MoveContainerItemsOnLoad extends ObjectReference Const
+
+Keyword Property MoveToLinkedRefOnKeyword = None Auto Const
+{ Items will be moved to whatever GetLinkedRef(MoveToLinkedRefOnKeyword) returns }
+
+Event OnInit()
+	StartTimer(3.0)
+EndEvent
+
+Event OnCellLoad()
+	StartTimer(3.0) ; Give a moment to ensure this container and the linked have finished respawning
+EndEvent
+
+Event OnTimer(Int aiTimerID)
+	MoveItems()
+EndEvent
+
+
+Function MoveItems()
+	ObjectReference kTargetRef = GetLinkedRef(MoveToLinkedRefOnKeyword)
+	
+	;Debug.Trace(">>>>>>>>>>>>>>> " + Self + " Moving " + Self.GetItemCount() + " items to " + kTargetRef)
+	
+	if(kTargetRef != None)
+		Self.RemoveAllItems(kTargetRef, false)
+	endif
+EndFunction

--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -164,6 +164,10 @@ Group VendorTypes
 	{ list of form lists, indexed by VendorType 
 		- each form list is indexed by vendor level
 	}
+	FormList[] Property WSFW_InjectionVendorContainers Auto Hidden ; Intentionally hidden - we'll fill on startup
+	{ list of form lists, indexed by VendorType 
+		- each form list is indexed by vendor level
+	}
 EndGroup
 
 Group FarmDiscount 
@@ -938,6 +942,12 @@ int iFormID_WSFW_NPCManager = 0x000091E2 Const
 int iFormID_WSFW_DoNotAutoassignKeyword = 0x000082A5 Const ; WSFW 1.0.8
 int iFormID_WSFW_MessageManager = 0x000092C5 Const ; WSFW 1.0.8
 int iFormID_WorkshopEnemyFaction = 0x001357E7 Const ; WSFW 1.1.10
+int iFormID_WSFW_InjectionVendorContainers_Armor = 0x000092B9 Const ; WSFW Version 2.0.17c
+int iFormID_WSFW_InjectionVendorContainers_Bar = 0x000092BA Const ; WSFW Version 2.0.17c
+int iFormID_WSFW_InjectionVendorContainers_Clinic = 0x000092BB Const ; WSFW Version 2.0.17c
+int iFormID_WSFW_InjectionVendorContainers_Clothing = 0x000092BC Const ; WSFW Version 2.0.17c
+int iFormID_WSFW_InjectionVendorContainers_General = 0x000092BD Const ; WSFW Version 2.0.17c
+int iFormID_WSFW_InjectionVendorContainers_Weapons = 0x000092BE Const ; WSFW Version 2.0.17c
 
 Function FillWSFWVars()
 	if( ! WSFW_NPCManager)
@@ -1024,6 +1034,48 @@ Function FillWSFWVars()
 	
 	if( ! WorkshopEnemyFaction)
 		WorkshopEnemyFaction = Game.GetFormFromFile(iFormID_WorkshopEnemyFaction, "Fallout4.esm") as Faction
+	endif
+	
+	if(WSFW_InjectionVendorContainers == None || WSFW_InjectionVendorContainers.Length == 0)
+		WSFW_InjectionVendorContainers = new Formlist[0]
+		
+		; Need to do these in same order as vanilla WorkshopVendorContainers array, which is: General, Armor, Weapons, Bar, Clinic, Clothing
+		
+		Formlist thisContainerList = Game.GetFormFromFile(iFormID_WSFW_InjectionVendorContainers_General, "WorkshopFramework.esm") as Formlist
+		
+		if(thisContainerList)
+			WSFW_InjectionVendorContainers.Add(thisContainerList)
+		endif
+		
+		thisContainerList = Game.GetFormFromFile(iFormID_WSFW_InjectionVendorContainers_Armor, "WorkshopFramework.esm") as Formlist
+		
+		if(thisContainerList)
+			WSFW_InjectionVendorContainers.Add(thisContainerList)
+		endif
+		
+		thisContainerList = Game.GetFormFromFile(iFormID_WSFW_InjectionVendorContainers_Weapons, "WorkshopFramework.esm") as Formlist
+		
+		if(thisContainerList)
+			WSFW_InjectionVendorContainers.Add(thisContainerList)
+		endif
+		
+		thisContainerList = Game.GetFormFromFile(iFormID_WSFW_InjectionVendorContainers_Bar, "WorkshopFramework.esm") as Formlist
+		
+		if(thisContainerList)
+			WSFW_InjectionVendorContainers.Add(thisContainerList)
+		endif
+		
+		thisContainerList = Game.GetFormFromFile(iFormID_WSFW_InjectionVendorContainers_Clinic, "WorkshopFramework.esm") as Formlist
+		
+		if(thisContainerList)
+			WSFW_InjectionVendorContainers.Add(thisContainerList)
+		endif
+		
+		thisContainerList = Game.GetFormFromFile(iFormID_WSFW_InjectionVendorContainers_Clothing, "WorkshopFramework.esm") as Formlist
+		
+		if(thisContainerList)
+			WSFW_InjectionVendorContainers.Add(thisContainerList)
+		endif
 	endif
 Endfunction
 

--- a/Scripts/Source/User/WorkshopScript.psc
+++ b/Scripts/Source/User/WorkshopScript.psc
@@ -1527,17 +1527,33 @@ ObjectReference[] function GetVendorContainersByType(int vendorType)
 	endif
 endFunction
 
+
 ObjectReference[] function InitializeVendorChests(int vendorType)
 	; initialize array
-	int containerArraySize = VendorTopLevel + 1
+	int containerArraySize = WorkshopParent.VendorTopLevel + 1
 	ObjectReference[] vendorContainers = new ObjectReference[containerArraySize]
 
 	; create the chests
 	FormList vendorContainerList = WorkshopParent.WorkshopVendorContainers[vendorType]
+	FormList WSFW_InjectionContainerList = WorkshopParent.WSFW_InjectionVendorContainers[vendorType]
+	
 	int vendorLevel = 0
-	while vendorLevel <= VendorTopLevel
+	while vendorLevel <= WorkshopParent.VendorTopLevel
 		; create ref for each vendor level
-		vendorContainers[vendorLevel] = WorkshopParent.WorkshopHoldingCellMarker.PlaceAtMe(vendorContainerList.GetAt(vendorLevel))
+		ObjectReference thisVendorContainer = WorkshopParent.WorkshopHoldingCellMarker.PlaceAtMe(vendorContainerList.GetAt(vendorLevel))
+		
+		vendorContainers[vendorLevel] = thisVendorContainer
+		
+		if(WSFW_InjectionContainerList != None)
+			ObjectReference kWSFWInjectionContainerRef = Self.PlaceAtMe(WSFW_InjectionContainerList.GetAt(vendorLevel))
+			
+			if(kWSFWInjectionContainerRef != None)
+				;Debug.Trace(">>>>>>>>>>>>>>> Linking injection container " + kWSFWInjectionContainerRef + " (base object: " + kWSFWInjectionContainerRef.GetBaseObject() + "), to vendor container " + thisVendorContainer + " (base object: " + kWSFWInjectionContainerRef.GetBaseObject() + ")")
+				
+				kWSFWInjectionContainerRef.SetLinkedRef(thisVendorContainer, (kWSFWInjectionContainerRef as WorkshopFramework:ObjectRefs:MoveContainerItemsOnLoad).MoveToLinkedRefOnKeyword)
+			endif
+		endif
+		
 		vendorLevel += 1
 	endWhile
 


### PR DESCRIPTION
- Made slight adjustment to auto-repair power grid code to ensure the entire cell is loaded before the code is run, which should reduce the likelihood of false positives.
- Power Grid Auto-Destroy and Auto-Repair are now disabled by default.
-- This system is designed to prevent corrupt power grids from causing crashes, and can be turned on for most players. For some players, it is destroying power grids that don’t appear to be corrupt in-game, despite what the code is reporting.
- Fixed a bug that prevented the Workshop Framework settlement vendor injection from functioning correctly. This fix is not retroactive and will only impact settlements the player acquires after this patch.