### PR TITLE
WSFW Alpha 2.0.20

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/F4SEManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/F4SEManager.psc
@@ -327,6 +327,7 @@ Function MCM_ScanPowerGrid()
 EndFunction
 
 
+
 Function ShowRemoteLocationManagementMenu()
 	; Pick Settlement
 	Location ChosenLocation = PlayerRef.OpenWorkshopSettlementMenuEx(None, ConfirmOverride_RemoteSettlement, abExcludeZeroPopulation = false, abOnlyOwnedWorkshops = false, abTurnOffHeader = true, abOnlyPotentialVassalSettlements = false, abDisableReservedByQuests = false)

--- a/Scripts/Source/User/WorkshopFramework/Library/SimpleInjectionManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/Library/SimpleInjectionManager.psc
@@ -1,0 +1,42 @@
+; ---------------------------------------------
+; WorkshopFramework:Library:SimpleInjectionManager.psc - by kinggath
+; ---------------------------------------------
+; Reusage Rights ------------------------------
+; You are free to use this script or portions of it in your own mods, provided you give me credit in your description and maintain this section of comments in any released source code (which includes the IMPORTED SCRIPT CREDIT section to give credit to anyone in the associated Import scripts below).
+; 
+; Warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Do not directly recompile this script for redistribution without first renaming it to avoid compatibility issues issues with the mod this came from.
+; 
+; IMPORTED SCRIPT CREDITS
+; N/A
+; ---------------------------------------------
+
+Scriptname WorkshopFramework:Library:SimpleInjectionManager extends WorkshopFramework:Library:SlaveQuest Conditional
+
+import WorkshopFramework:Library:DataStructures
+
+InjectionMap[] Property InjectData Auto Const
+
+int iLastInjectedIndex = -1
+
+Function HandleGameLoaded()
+	Parent.HandleGameLoaded()
+	
+	HandleInjections()
+EndFunction
+
+Function HandleInjections()
+	int i = iLastInjectedIndex + 1
+	while(i < InjectData.Length)
+		iLastInjectedIndex = i
+		
+		int j = 0
+		while(j < InjectData[i].NewEntries.GetSize())
+			InjectData[i].TargetLeveledItem.AddForm(InjectData[i].NewEntries.GetAt(j), InjectData[i].iLevel, InjectData[i].iCount)
+			
+			j += 1
+		endWhile
+		
+		i += 1
+	endWhile
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/MoveContainerItemsOnLoad.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/MoveContainerItemsOnLoad.psc
@@ -1,5 +1,7 @@
 Scriptname WorkshopFramework:ObjectRefs:MoveContainerItemsOnLoad extends ObjectReference Const
 
+import WorkshopFramework:Library:UtilityFunctions
+
 Keyword Property MoveToLinkedRefOnKeyword = None Auto Const
 { Items will be moved to whatever GetLinkedRef(MoveToLinkedRefOnKeyword) returns }
 
@@ -19,7 +21,8 @@ EndEvent
 Function MoveItems()
 	ObjectReference kTargetRef = GetLinkedRef(MoveToLinkedRefOnKeyword)
 	
-	;Debug.Trace(">>>>>>>>>>>>>>> " + Self + " Moving " + Self.GetItemCount() + " items to " + kTargetRef)
+	ModTrace(">>>>>>>>>>>>>>> " + Self + " Moving " + Self.GetItemCount() + " items to " + kTargetRef)
+	
 	
 	if(kTargetRef != None)
 		Self.RemoveAllItems(kTargetRef, false)

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/SelfResettingRef.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/SelfResettingRef.psc
@@ -1,0 +1,32 @@
+Scriptname WorkshopFramework:ObjectRefs:SelfResettingRef extends ObjectReference
+
+import WorkshopFramework:Library:UtilityFunctions
+
+Float Property fResetTime = 0.0 Auto Const
+{ If set, this container will be set to reset every this many game hours }
+
+Bool bResetTimerRunning = false
+
+Event OnInit()
+	if(fResetTime > 0.0 && ! bResetTimerRunning)
+		StartResetTimer()
+	endif
+EndEvent
+
+Event OnCellLoad()
+	if(fResetTime > 0.0 && ! bResetTimerRunning)
+		Reset() ; Immediately reset the first time to ensure in correct state
+		StartResetTimer()
+	endif
+EndEvent
+
+
+Event OnTimerGameTime(Int aiTimerID)
+	Reset()
+	StartResetTimer()
+EndEvent
+
+Function StartResetTimer()
+	StartTimerGameTime(fResetTime)
+	bResetTimerRunning = true
+EndFunction

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
@@ -34,6 +34,8 @@ ActorValue Property PowerRequired Auto Const Mandatory
 { Autofill }
 ActorValue Property PowerGenerated Auto Const Mandatory
 { Autofill }
+ActorValue Property WorkshopSnapTransmitsPower Auto Const Mandatory
+{ Autofill }
 ActorValue Property WorkshopResourceObject Auto Const Mandatory
 { Autofill }
 ActorValue Property WorkshopCurrentDraws Auto Const Mandatory
@@ -41,6 +43,8 @@ ActorValue Property WorkshopCurrentDraws Auto Const Mandatory
 ActorValue Property WorkshopCurrentTriangles Auto Const Mandatory
 { Autofill }
 Keyword Property WorkshopCanBePowered Auto Const Mandatory
+{ Autofill }
+Keyword Property WorkshopPowerConnectionDUPLICATE000 Auto Const Mandatory
 { Autofill }
 Keyword Property WorkshopItemKeyword Auto Const Mandatory
 { Autofill }
@@ -82,6 +86,7 @@ Float Property fAngleY = 0.0 Auto Hidden
 Float Property fAngleZ = 0.0 Auto Hidden 
 Float Property fScale = 1.0 Auto Hidden ; 1.1.6 - Defaulting to 1
 Bool Property bFadeIn = false Auto Hidden ; 1.0.5 - Adding option to allow fading these items in instead of popping them in
+Bool Property bPreventAddingToPowerGrid = false Auto Hidden ; 2.0.20 - Adding option to ensure the item spawned can't become part of a power grid
 Bool Property bStartEnabled = true Auto Hidden
 Bool Property bForceStatic = false Auto Hidden ; 1.0.5 - Default to false
 Bool Property bFauxPowered = false Auto Hidden ; 1.0.5 - Default to false
@@ -357,7 +362,9 @@ Function RunCode()
 				endif
 				
 				if(kResult.HasKeyword(WorkshopCanBePowered))
-					if(bFauxPowered)
+					if(bPreventAddingToPowerGrid)
+						PreventAddingToPowerGrid(kResult)
+					elseif(bFauxPowered)
 						FauxPowered(kResult)
 					endif
 					
@@ -542,6 +549,14 @@ Function FauxPowered(ObjectReference akRef)
 	akRef.SetValue(PowerGenerated, 0.1)
 	akRef.SetValue(WorkshopResourceObject, 1.0)
 	akRef.AddKeyword(FauxPoweredKeyword)
+EndFunction
+
+
+Function PreventAddingToPowerGrid(ObjectReference akRef)
+	akRef.RemoveKeyword(WorkshopCanBePowered)
+	akRef.RemoveKeyword(WorkshopPowerConnectionDUPLICATE000)
+	akRef.SetValue(PowerGenerated, 0.0)
+	akRef.SetValue(WorkshopSnapTransmitsPower, 0.0)
 EndFunction
 
 

--- a/Scripts/Source/User/WorkshopFramework/UIManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/UIManager.psc
@@ -74,6 +74,8 @@ Group MessageSelectorSystem
 	ReferenceAlias Property MessageSelectorTitleAlias Auto Const Mandatory
 	ReferenceAlias[] Property MessageSelectorItemLineAliases Auto Const Mandatory
 	{ REMINDER: You must set up different Message forms to handle more aliases, our default (MessageSelector_Default) only displays one for the title of the selection type and another for the current option. }
+	
+	Form Property RenamableDummyForm Auto Const Mandatory
 EndGroup
 
 Group SettlementSelect
@@ -993,6 +995,11 @@ EndFunction
 
 
 Int Function ShowMessageSelectorMenuFormlistAndWaitV2(Formlist aSelectFromOptionsList, Form aMessageTitleNameHolder = None, Message aNoOptionsWarningOverride = None, Float afMaxWaitForSelector = 0.0)
+	return ShowMessageSelectorMenuFormlistAndWaitV3(aSelectFromOptionsList, aMessageTitleNameHolder, aNoOptionsWarningOverride, afMaxWaitForSelector, aiStartingIndex = 0)
+EndFunction
+
+
+Int Function ShowMessageSelectorMenuFormlistAndWaitV3(Formlist aSelectFromOptionsList, Form aMessageTitleNameHolder = None, Message aNoOptionsWarningOverride = None, Float afMaxWaitForSelector = 0.0, Int aiStartingIndex = 0)
 	if( ! aSelectFromOptionsList)
 		return iMessageSelectorReturn_Failure
 	endif
@@ -1060,7 +1067,7 @@ Int Function ShowMessageSelectorMenuFormlistAndWaitV2(Formlist aSelectFromOption
 	MessageSelectorTitleAlias.ForceRefTo(kTitleRef)
 	
 	; Start the selection loop
-	ShowMessageSelectorMenuLoop_InternalOnly(aiIndexToDisplay = 0, aiSource = iSource)
+	ShowMessageSelectorMenuLoop_InternalOnly(aiIndexToDisplay = aiStartingIndex, aiSource = iSource)
 	
 	bMessageSelectorInUse = false
 	MessageSelectorFormArray = new Form[0] ; Clear this array
@@ -1092,8 +1099,14 @@ Function ShowMessageSelectorMenuLoop_InternalOnly(Int aiIndexToDisplay = 0, Int 
 		endif
 		
 		; Setup text replacement
-		ObjectReference kNameRef = kSafeSpawnPoint.PlaceAtMe(CurrentForm)
-		MessageSelectorItemLineAliases[0].ForceRefTo(kNameRef)
+		if(CurrentForm as Message)
+			ObjectReference kNameRef = kSafeSpawnPoint.PlaceAtMe(RenamableDummyForm)
+			kNameRef.AddTextReplacementData("RenameMe", CurrentForm)
+			MessageSelectorItemLineAliases[0].ForceRefTo(kNameRef)
+		else
+			ObjectReference kNameRef = kSafeSpawnPoint.PlaceAtMe(CurrentForm)
+			MessageSelectorItemLineAliases[0].ForceRefTo(kNameRef)
+		endif
 		
 		; Should we show More Info option?
 		MenuControl_MessageSelector_MoreInfo.SetValueInt(0)


### PR DESCRIPTION
- UIManager now supports Messages as a viable naming forms when using the ShowMessageSelectorMenu system.
- Added ShowMessageSelectorMenuFormlistAndWaitV3, this adds an additional field to the signature: aiStartingIndex, which allows for starting the message loop at a particular index.
- Fixed a bug in the workshop consumption code that would cause all calls to use resources from the settlement’s caravan network, even if the consumption call explicitly requested to use local resources only. This would only have impacted mods calling the ConsumeFromWorkshop functions.
- Fixed a bug that would cause settlement vendor injection through Workshop Framework to not correctly reset every 48 hours alongside the default vendor wares.
- Added new script to library called SimpleInjectionManager. This can be used to inject items from a formlist into a leveled item.