### PR TITLE
2.0.21 Live

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/NPCManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/NPCManager.psc
@@ -953,6 +953,8 @@ EndFunction
 /;
 ;
 Function AssignNPCToObject(WorkshopObjectScript akWorkshopObject, Actor akNewActor = None, Bool abAutoHandleNPCAssignmentRules = true, Bool abAutoUpdateWorkshopNPCStatus = true, Bool abRecalculateWorkshopResources = true, Bool abGetLock = false)
+ 
+	ModTrace("NPCManager.AssignNPCToObject(" + akWorkshopObject + ", " + akNewActor + ", abAutoHandleNPCAssignmentRules = " + abAutoHandleNPCAssignmentRules + ", abAutoUpdateWorkshopNPCStatus = " + abAutoUpdateWorkshopNPCStatus + ", abRecalculateWorkshopResources = " + abRecalculateWorkshopResources + ", abGetLock = " + abGetLock + ")")
 	if( ! akWorkshopObject)
 		return
 	endif
@@ -987,8 +989,10 @@ Function AssignNPCToObject(WorkshopObjectScript akWorkshopObject, Actor akNewAct
 			
 			; Let workshopObject handle most code - this allows to have item level overrides
 			if(asWorkshopNPC) ; 2.0.4 - We need to call AssignActor or any workshop object overriding it won't be called
+				ModTrace("NPCManager.AssignNPCToObject calling AssignActor on " + akWorkshopObject)
 				akWorkshopObject.AssignActor(asWorkshopNPC)
 			else
+				ModTrace("NPCManager.AssignNPCToObject calling AssignNPC on " + akWorkshopObject)
 				akWorkshopObject.AssignNPC(akNewActor)
 			endif
 			

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
@@ -515,7 +515,7 @@ Function ConfigureRadio(WorkshopObjectScript akWorkshopObject, WorkshopScript ak
 				akWorkshopRef.WorkshopRadioScene.Start()
 			endif
 		else 
-			akWorkshopObject.MakeTransmitterRepeater(WorkshopRadioRef, akWorkshopRef.workshopRadioInnerRadius, akWorkshopRef.workshopRadioOuterRadius)
+			akWorkshopObject.MakeTransmitterRepeater(WorkshopParent.WorkshopRadioRef, akWorkshopRef.workshopRadioInnerRadius, akWorkshopRef.workshopRadioOuterRadius)
 			if(WorkshopRadioScene01.IsPlaying() == false)
 				WorkshopRadioScene01.Start()
 			endif
@@ -525,13 +525,15 @@ Function ConfigureRadio(WorkshopObjectScript akWorkshopObject, WorkshopScript ak
 			WorkshopEventRadioBeacon.SendStoryEvent(akRef1 = akWorkshopRef)
 		endif
 	else
-		akWorkshopObject.MakeTransmitterRepeater(NONE, 0, 0)
-		
 		; if unique radio, turn it off completely
 		if(akWorkshopRef.WorkshopRadioRef && akWorkshopRef.bWorkshopRadioRefIsUnique)
+			akWorkshopObject.MakeTransmitterRepeater(akWorkshopRef.WorkshopRadioRef, 0, 0)
+			
 			akWorkshopRef.WorkshopRadioRef.Disable()
 			; stop custom scene if unique
 			akWorkshopRef.WorkshopRadioScene.Stop()
+		else
+			akWorkshopObject.MakeTransmitterRepeater(WorkshopParent.WorkshopRadioRef, 0, 0)
 		endif
 	endif
 	

--- a/Scripts/Source/User/WorkshopFramework/WorkshopFunctions.psc
+++ b/Scripts/Source/User/WorkshopFramework/WorkshopFunctions.psc
@@ -1208,7 +1208,7 @@ EndFunction
 /;
 Function AssignActorToObject(WorkshopObjectScript akWorkshopObject, Actor akNewActor = None, Bool abAutoHandleAssignmentRules = true, Bool abAutoUpdateActorStatus = true, Bool abRecalculateWorkshopResources = true) global
 	WorkshopFramework:NPCManager NPCManager = GetNPCManager()
-	
+	Debug.Trace("      WorkshopFunctions.AssignActorToObject called. Calling AssignNPCToObject on " + NPCManager)
 	NPCManager.AssignNPCToObject(akWorkshopObject, akNewActor, abAutoHandleAssignmentRules, abAutoUpdateActorStatus, abRecalculateWorkshopResources, abGetLock = true)
 EndFunction
 

--- a/Scripts/Source/User/WorkshopObjectScript.psc
+++ b/Scripts/Source/User/WorkshopObjectScript.psc
@@ -403,9 +403,11 @@ endFunction
 
 
 Function AssignNPC(Actor newActor = None)
+	; Debug.Trace("     WorkshopObjectScript.AssignNPC(" + newActor + ")")
 	if(newActor)
 		; if this is a bed, and has faction ownership OR actor base ownership, just keep it
 		if( ! IsBed() || ! IsOwnedBy(newActor))
+			; Debug.Trace("     WorkshopObjectScript " + Self + " AssignNPC calling SetActorRefOwner " + newActor)
 			SetActorRefOwner(newActor, true)
 		endif
 		
@@ -661,6 +663,9 @@ endFunction
 
 Event OnActivate(ObjectReference akActionRef)
 	;WorkshopParent.wsTrace(self + " activated by " + akActionRef + " isradio?" + HasKeyword(WorkshopParent.WorkshopRadioObject))
+	
+	; Debug.Trace(self + " activated by " + akActionRef + " isradio?" + HasKeyword(WorkshopParent.WorkshopRadioObject) + ", CanProduceForWorkshop()? " + CanProduceForWorkshop())
+	
 	if akActionRef == Game.Getplayer() 
 		;WorkshopParent.wstrace(self + " activated by player")
 		if CanProduceForWorkshop()
@@ -671,6 +676,11 @@ Event OnActivate(ObjectReference akActionRef)
 				WorkshopParent.UpdateRadioObject(self)
 			endif
 		else
+			; Can't produce, so power must be off
+			if HasKeyword(WorkshopParent.WorkshopRadioObject)
+				bRadioOn = false
+				WorkshopParent.UpdateRadioObject(self)
+			endif
 		endif
 		
 		; player comment

--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -3360,14 +3360,16 @@ function UpdateRadioObject(WorkshopObjectScript radioObject)
 			WorkshopEventRadioBeacon.SendStoryEvent(akRef1 = workshopRef)
 		endif
 	else		
-		radioObject.MakeTransmitterRepeater(NONE, 0, 0)
-		
 		; if unique radio, turn it off completely
 		if(workshopRef.WorkshopRadioRef && workshopRef.bWorkshopRadioRefIsUnique)
+			radioObject.MakeTransmitterRepeater(workshopRef.WorkshopRadioRef, 0, 0)
+			
 			workshopRef.WorkshopRadioRef.Disable()
 			
 			; stop custom scene if unique
 			workshopRef.WorkshopRadioScene.Stop()
+		else
+			radioObject.MakeTransmitterRepeater(WorkshopRadioRef, 0, 0)
 		endif
 	endif
 	
@@ -3887,7 +3889,8 @@ endFunction
 
 
 ; clear and recalculate workshop ratings
-function ResetWorkshop(WorkshopScript workshopRef)
+function ResetWorkshop(WorkshopScript workshopRef)	
+	
 	int workshopID = workshopRef.GetWorkshopID()
 
 	if(workshopID != currentWorkshopID)
@@ -3951,6 +3954,7 @@ function ResetWorkshop(WorkshopScript workshopRef)
 	workshopRef.RecalculateWorkshopResources(false)
 	WorkshopCenterMarker.ForceRefTo(workshopRef.GetLinkedRef(WorkshopLinkCenter))
 
+	
 	;ADD THE ACTORS:
 	int maxIndex = WorkshopActors.length
 	


### PR DESCRIPTION
- Added boolean to the RecalculateWorkshopResources function to prevent it from running again while a previous call was running.
- RecalculateWorkshopResources function will now reset the WorkshopItemKeyword link for all settlers. This will fix an issue that can occur with Provisioners or radiant kidnapped settlers where they end up not counting towards the population any longer and can become unassigned from their beds or other work objects.
- Fixed a vanilla bug that would prevent turning off a Settlement Recruitment Beacon from actually changing the transmission of the radio signal.