### PR TITLE
2.1.0

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -40,6 +40,8 @@ Group Controllers
 	WorkshopFramework:SettlementLayoutManager Property SettlementLayoutManager Auto Const Mandatory
 	
 	WorkshopFramework:F4SEManager Property F4SEManager Auto Const Mandatory
+	
+	WorkshopFramework:UIManager Property UIManager Auto Const Mandatory
 EndGroup
 
 
@@ -148,7 +150,7 @@ Event OnTimer(Int aiTimerID)
 				if(bLeavingWorkshopLocation && ! bEnteringWorkshopLocation && currentWorkshop && ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
 					currentWorkshop = None
 				else
-					if(currentWorkshop.myLocation != None)
+					if(currentWorkshop != None && currentWorkshop.myLocation != None)
 						; Player is in limbo area - it is not flagged as part of a specific location (likely just the overworld location - ie. Commonwealth) and so another LocationChange event isn't likely to fire - so instead we'll do a 5 second repeating loop to check if they returned to the location tagged part of the settlement or are out of the build area
 						StartTimer(fTimerLength_BuildableAreaCheck, iTimerID_BuildableAreaCheck)
 
@@ -244,7 +246,7 @@ Event OnMenuOpenCloseEvent(string asMenuName, bool abOpening)
 
 			if(lastWorkshop != currentWorkshop)
 				 ; If this happens, there is likely some serious script lag happening - but since LastWorkshopAlias is used throughout our code, we don't ever want it to be incorrect, so use this opportunity to correct it
-				 if( ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
+				 if(currentWorkshop == None || ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
 					; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
 					currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
 				endif
@@ -273,6 +275,13 @@ EndEvent
 ; ---------------------------------------------
 
 Function HandleInstallModChanges()
+	Int iVersion210 = 53
+	if(iInstalledVersion < iVersion210)
+		UIManager.Stop()
+		Utility.Wait(1.0)
+		UIManager.Start()
+	endif
+	
 	if(iInstalledVersion < 26)
 		PlayerRef.AddPerk(ActivationPerk)
 	endif

--- a/Scripts/Source/User/WorkshopFramework/Quests/DoorManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/Quests/DoorManager.psc
@@ -106,7 +106,7 @@ EndEvent
 
 
 Event ObjectReference.OnOpen(ObjectReference akRef, ObjectReference akOpenedBy)
-	if(Setting_DoorManagement.GetValue() == 0 || (akOpenedBy != PlayerRef && Setting_AutoCloseDoorsOpenedByPlayer.GetValue() == 0) || (akOpenedBy == PlayerRef && Setting_AutoCloseDoorsOpenedByNPCs.GetValue() == 0) || akRef.HasKeyword(DoNotAutoCloseMe))
+	if(Setting_DoorManagement.GetValue() == 0 || (akOpenedBy == PlayerRef && Setting_AutoCloseDoorsOpenedByPlayer.GetValue() == 0) || (akOpenedBy != PlayerRef && Setting_AutoCloseDoorsOpenedByNPCs.GetValue() == 0) || akRef.HasKeyword(DoNotAutoCloseMe))
 		return
 	endif
 	
@@ -266,7 +266,15 @@ Int Function FindQueueIndex(ObjectReference akRef)
 		
 			if(index < 0)
 				index = DoorsToClose04.Find(akRef)
+				
+				if(index >= 0)
+					index += 384
+				endif
+			else
+				index += 256
 			endif
+		else
+			index += 128
 		endif
 	endif
 	
@@ -294,7 +302,7 @@ EndFunction
 Function AddToQueue(ObjectReference akRef)
 	Int index = FindQueueIndex(akRef)
 	
-	if(index <= 0)
+	if(index < 0)
 		int iNewIndex = NextQueueSlot
 		
 		if(iNewIndex >= 384)
@@ -385,47 +393,33 @@ Function ToggleAllDoors(WorkshopScript akWorkshopRef, Bool abOpen = true)
 	bAllDoorTogglingInProgress = true
 	bOpeningAllDoors = abOpen
 	
-	; Use an event to find all doors linked to the ref
-	int iCallerID = Utility.RandomInt(0, 999999)
-	
-	if(EventKeyword_DoorFinder.SendStoryEventAndWait(akWorkshopRef.myLocation, aiValue1 = iCallerID))
-		Utility.Wait(0.1) ; Give finder a moment to configure it's caller ID variable
-		WorkshopFramework:Quests:DoorFinder DoorFinder = None
-		int iQuestIndex = 0
-		while(iQuestIndex < DoorFinders.Length && DoorFinder == None)
-			if(DoorFinders[iQuestIndex].iCallerID == iCallerID)
-				DoorFinder = DoorFinders[iQuestIndex]
+	WorkshopFramework:Quests:DoorFinder DoorFinder = GetDoorFinder(akWorkshopRef)
+		
+	if(DoorFinder != None)
+		int i = 0
+		RefCollectionAlias FoundDoors = DoorFinder.SettlementDoors
+		
+		while(i < FoundDoors.GetCount())
+			ObjectReference thisDoor = FoundDoors.GetAt(i)
+			if( ! thisDoor.IsDisabled())
+				if( ! abOpen)
+					if( ! thisDoor.HasKeyword(DoNotAutoCloseMe))
+						thisDoor.SetOpen(false)
+					endif
+				else
+					; Unregister temporarily to avoid a bunch of event spam
+					UnregisterDoor(thisDoor)
+					
+					thisDoor.SetOpen(true)
+					
+					RegisterDoor(thisDoor)
+				endif
 			endif
 			
-			iQuestIndex += 1
+			i += 1
 		endWhile
 		
-		if(DoorFinder != None)
-			int i = 0
-			RefCollectionAlias FoundDoors = DoorFinder.SettlementDoors
-			
-			while(i < FoundDoors.GetCount())
-				ObjectReference thisDoor = FoundDoors.GetAt(i)
-				if( ! thisDoor.IsDisabled())
-					if( ! abOpen)
-						if( ! thisDoor.HasKeyword(DoNotAutoCloseMe))
-							thisDoor.SetOpen(false)
-						endif
-					else
-						; Unregister temporarily to avoid a bunch of event spam
-						UnregisterDoor(thisDoor)
-						
-						thisDoor.SetOpen(true)
-						
-						RegisterDoor(thisDoor)
-					endif
-				endif
-				
-				i += 1
-			endWhile
-			
-			DoorFinder.Stop()
-		endif
+		DoorFinder.Stop()
 	endif
 	
 	bAllDoorTogglingInProgress = false	
@@ -445,50 +439,36 @@ Function RegisterAllDoors(WorkshopScript akWorkshopRef)
 	
 	bDoorRegistrationInProgress[iWorkshopID] = true
 	
-	; Use an event to find all doors linked to the ref
-	int iCallerID = Utility.RandomInt(0, 999999)
-	
-	if(EventKeyword_DoorFinder.SendStoryEventAndWait(akWorkshopRef.myLocation, aiValue1 = iCallerID))
-		Utility.Wait(0.1) ; Give finder a moment to configure it's caller ID variable
-		WorkshopFramework:Quests:DoorFinder DoorFinder = None
-		int iQuestIndex = 0
-		while(iQuestIndex < DoorFinders.Length && DoorFinder == None)
-			if(DoorFinders[iQuestIndex].iCallerID == iCallerID)
-				DoorFinder = DoorFinders[iQuestIndex]
+	WorkshopFramework:Quests:DoorFinder DoorFinder = GetDoorFinder(akWorkshopRef)
+		
+	if(DoorFinder != None)		
+		int i = 0
+		RefCollectionAlias FoundDoors = DoorFinder.SettlementDoors
+		int iCount = FoundDoors.GetCount()
+		
+		while(i < iCount)
+			ObjectReference thisDoor = FoundDoors.GetAt(i)
+			if(thisDoor != None)
+				RegisterDoor(thisDoor)
 			endif
 			
-			iQuestIndex += 1
+			i += 1
 		endWhile
 		
-		if(DoorFinder != None)		
-			int i = 0
-			RefCollectionAlias FoundDoors = DoorFinder.SettlementDoors
-			int iCount = FoundDoors.GetCount()
+		; Clean up deleted doors
+		RefCollectionAlias DisabledDoors = DoorFinder.DisabledDoors
+		i = 0
+		iCount = DisabledDoors.GetCount()
+		while(i < iCount)
+			ObjectReference thisDoor = FoundDoors.GetAt(i)
+			if(thisDoor != None && thisDoor.IsDeleted())
+				UnregisterDoor(thisDoor)
+			endif
 			
-			while(i < iCount)
-				ObjectReference thisDoor = FoundDoors.GetAt(i)
-				if(thisDoor != None)
-					RegisterDoor(thisDoor)
-				endif
-				
-				i += 1
-			endWhile
-			
-			; Clean up deleted doors
-			RefCollectionAlias DisabledDoors = DoorFinder.DisabledDoors
-			i = 0
-			iCount = DisabledDoors.GetCount()
-			while(i < iCount)
-				ObjectReference thisDoor = FoundDoors.GetAt(i)
-				if(thisDoor != None && thisDoor.IsDeleted())
-					UnregisterDoor(thisDoor)
-				endif
-				
-				i += 1
-			endWhile
-			
-			DoorFinder.Stop()
-		endif
+			i += 1
+		endWhile
+		
+		DoorFinder.Stop()
 	endif
 	
 	bDoorRegistrationInProgress[iWorkshopID] = false
@@ -503,4 +483,43 @@ Function SettingsUpdated()
 		; Let's make sure events for this settlement are registered for and all doors are registered
 		HandlePlayerEnteredSettlement(kWorkshopRef)
 	endif
+EndFunction
+
+
+
+WorkshopFramework:Quests:DoorFinder Function GetDoorFinder(WorkshopScript akWorkshopRef)
+	if ( akWorkshopRef == none )
+		return none
+	endif
+
+	; Use an event to find all doors linked to the ref
+	int iCallerID = Utility.RandomInt(0, 999999)
+	WorkshopFramework:Quests:DoorFinder DoorFinder = None
+
+	if ( EventKeyword_DoorFinder.SendStoryEventAndWait(akWorkshopRef.myLocation, aiValue1 = iCallerID) )
+		Utility.Wait(0.1) ; Give finder a moment to configure it's caller ID variable
+		int iQuestIndex = 0
+		while(iQuestIndex < DoorFinders.Length && DoorFinder == None)
+			if(DoorFinders[iQuestIndex].iCallerID == iCallerID)
+				DoorFinder = DoorFinders[iQuestIndex]
+			endif
+
+			iQuestIndex += 1
+		endWhile
+	endif
+
+	return DoorFinder
+EndFunction
+
+Function ForceRegisterAllDoors() DebugOnly
+	; debug function for force register all settlement doors
+	WorkshopScript kWorkshopRef = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
+
+	if ( kWorkshopRef == none )
+		return
+	endif
+
+	int iWorkshopID = kWorkshopRef.GetWorkshopID()
+	bDoorRegistrationInProgress[iWorkshopID] = false	; make sure this is false so we do not return early when calling RegisterAllDoors
+	RegisterAllDoors(kWorkshopRef)
 EndFunction

--- a/Scripts/Source/User/WorkshopFramework/Weapons/SettlementLayout.psc
+++ b/Scripts/Source/User/WorkshopFramework/Weapons/SettlementLayout.psc
@@ -1043,23 +1043,6 @@ Function PowerUp(WorkshopScript akWorkshopRef)
 EndFunction
 
 
-Function ShutOffSkipPowerItems(WorkshopScript akWorkshopRef)
-	if( ! akWorkshopRef.Is3dLoaded())
-		return
-	endif
-	
-	Formlist SkipPowerOnList = GetSkipPowerOnList()
-	ObjectReference[] ShutMeDown = akWorkshopRef.FindAllReferencesOfType(SkipPowerOnList, 20000.0) 
-	
-	int i = 0
-	while(i < ShutMeDown.Length)
-		ShutMeDown[i].SetOpen(false) ; This will turn off any switches on the devices
-		ShutMeDown[i].OnPowerOff()
-						
-		i += 1
-	endWhile
-EndFunction
-
 
 ObjectReference Function FindPowereableRef(PowerConnectionLookup[] aLookupGroup, PowerConnectionMap aPowerConnectionMap, Bool abSearchForIndexA = true)
 	if(aLookupGroup.Length > 0)
@@ -1125,10 +1108,6 @@ EndFunction
 
 Keyword Function GetWorkshopKeyword()
 	return Game.GetFormFromFile(0x00054BA7, "Fallout4.esm") as Keyword
-EndFunction
-
-Formlist Function GetSkipPowerOnList()
-	return Game.GetFormFromFile(0x000158CD, "WorkshopFramework.esm") as Formlist
 EndFunction
 
 ActorValue Function GetWorkshopPowerConnectionAV()


### PR DESCRIPTION
- Added ShowSettlementBarterSelectMenuV2 to UIManager, which adds an additional parameter for telling which settlements to show as pre-selected.
- Added several sanity checks to avoid log spam in the MainQuest script when a settlement isn’t detected as the current workshop.
- Fixed a bug with auto closing doors feature that would cause the NPC and Player versions of the settings to act in reverse of what the player set.
- Fixed a bug that would prevent more than 128 doors found in a settlement from working with the Auto Close Door feature.
- Fresh Facials and Orphans of the Commonwealth removed from the list of mods to disable injection for. Both of these mods now have patches available to work with the WSFW injection system.
- Added ShowCachedBarterSelectMenuV4, ShowFormlistBarterSelectMenuV4, ShowBarterSelectMenuV4, ShowFormlistBarterSelectMenuAndWaitV3, ShowCachedBarterSelectMenuAndWaitV3, and ShowBarterSelectMenuAndWaitV3 functions to UIManager. These versions break up the the previous abUsingReferences parameter into 3 separate ones, giving more flexibility to how the system can be used.
--- abAvailableOptionItemsAreReferences: Which means the options the player to choose from should be treated as references.
--- abStartBarterSelectedFormlistAreReferences: Which means the forms sent in the aStartBarterSelectedFormlist should be treated as references.
--- abStoreResultsAsReferences: Which means that references should be returned in aStoreResultsIn rather than base forms. This option only matters when abAvailableOptionItemsAreReferences is true, as otherwise there are no references to return.
- UIManager will now mark new references it creates for the barter menu system as stolen if the calling function requested stolen only. This should resolve an issue with using selectable references and stolen only options together.
- Overhauled the way UIManager’s barter menus work to use individual vendors for each combination of filtering. Previously, the system relied on reconfiguring a specific vendor to match the setting, but certain combinations of settings could cause the vendor’s barter config to get stuck until the save was reloaded.
