### PR TITLE
DoorManager v2.1.1 bugfix

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Quests/DoorManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/Quests/DoorManager.psc
@@ -456,9 +456,9 @@ Function RegisterAllDoors(WorkshopScript akWorkshopRef)
 		endWhile
 		
 		; Clean up deleted doors
-		RefCollectionAlias DisabledDoors = DoorFinder.DisabledDoors
+		FoundDoors = DoorFinder.DisabledDoors
 		i = 0
-		iCount = DisabledDoors.GetCount()
+		iCount = FoundDoors.GetCount()
 		while(i < iCount)
 			ObjectReference thisDoor = FoundDoors.GetAt(i)
 			if(thisDoor != None && thisDoor.IsDeleted())


### PR DESCRIPTION
L463 referencing incorrect ReferenceAlias
Changed to recycle var FoundDoors for the clean up deleted doors loop. We really don't need to define a new var for this.

Previous pull request was closed to to something weird going on. I deleted and created a new fork and am re-submitting...