### PR TITLE
Give GetVendorLevel a failsafe return value

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/RealInventoryDisplay.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/RealInventoryDisplay.psc
@@ -134,6 +134,8 @@ Int Function GetVendorLevel()
 			return ((Self as ObjectReference) as WorkshopObjectScript).VendorLevel
 		endif
 	endif
+	
+	return 2	; just default to a L3 vendor if we failed to get iVendorLevel previously
 EndFunction
 
 Function CreateRealInventoryDisplayMarkerRefs()


### PR DESCRIPTION
Its possible for GetVendorLevel to fail to return a value. Add a return value in case this happens.