### PR TITLE
WorkshopParentScript - AssignObjectToWorkshop

### DIFF
--- a/Scripts/Source/User/WorkshopParentScript.psc
+++ b/Scripts/Source/User/WorkshopParentScript.psc
@@ -3218,7 +3218,7 @@ function AssignObjectToWorkshop(WorkshopObjectScript workObject, WorkshopScript 
 		endif
 
 		;if workshop is the current workshop, add all unowned beds to the UFO4P_UnassignedBeds array:
-		if(UFO4P_Owned == false && workshopRef.GetWorkshopID() == currentWorkshopID)
+		if(UFO4P_Owned == false && workshopID == currentWorkshopID)	; we already set workshopID = workshopRef.GetWorkshopID(), no need to call it again
 			UFO4P_AddUnassignedBedToArray(workObject)
 			
 			if( ! bResetMode && AutoAssignBeds)


### PR DESCRIPTION
A small optimization to AssignObjectToWorkshop
workshopRef.GetWorkshopID() is called twice. The first call sets workshopID, so I replaced the second call with workshopID.