### PR TITLE
Sanctuary reset fix

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -828,10 +828,15 @@ Function CheckForWorkshopScriptOverwrites()
 	WorkshopScript kSanctuaryRef = Game.GetFormFromFile(0x000250FE, "Fallout4.esm") as WorkshopScript
 	
 	; Make sure vars had a chance to fill
+	
+	; Option #1, check for player ownership
 	if ( ! kSanctuaryRef.OwnedByPlayer )
 		; assume if workshop owned, vars are filled - calling OnInit on an owned workshop will reset the build limit AVs
 		kSanctuaryRef.OnInit() ; if WSFW version is installed, this will call FillWSFWVars() on it and WorkshopParent
 	endif
+	
+	; Option #2, call OnLoad instead of OnInit
+	; kSanctuaryRef.OnLoad()
 		
 	; Check WorkshopParent
 	var WorkshopParentCheck = WorkshopParent.GetPropertyValue("WSFW_Setting_AutoAssignBeds")

--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -828,7 +828,10 @@ Function CheckForWorkshopScriptOverwrites()
 	WorkshopScript kSanctuaryRef = Game.GetFormFromFile(0x000250FE, "Fallout4.esm") as WorkshopScript
 	
 	; Make sure vars had a chance to fill
-	kSanctuaryRef.OnInit() ; if WSFW version is installed, this will call FillWSFWVars() on it and WorkshopParent
+	if ( ! kSanctuaryRef.OwnedByPlayer )
+		; assume if workshop owned, vars are filled - calling OnInit on an owned workshop will reset the build limit AVs
+		kSanctuaryRef.OnInit() ; if WSFW version is installed, this will call FillWSFWVars() on it and WorkshopParent
+	endif
 		
 	; Check WorkshopParent
 	var WorkshopParentCheck = WorkshopParent.GetPropertyValue("WSFW_Setting_AutoAssignBeds")


### PR DESCRIPTION
I think I figured out the "Sanctuary Reset" Bug. Its being caused by the new WSFW `MainQuest.CheckForWorkshopScriptOverwrites` function.

https://github.com/msalaba01/WorkshopFramework/blob/0ff3dcea162655ebb9bf36311645dd3a4e5d8a17/Scripts/Source/User/WorkshopFramework/MainQuest.psc#L823-L831

Its calling WorkshopScript.OnInit which resets the build limit and settlement happiness:
https://github.com/msalaba01/WorkshopFramework/blob/0ff3dcea162655ebb9bf36311645dd3a4e5d8a17/Scripts/Source/User/WorkshopScript.psc#L1632-L1660

To fix, one option is to only call OnInit if the workshop is not owned by the player.
The other is to call kSanctuaryRef.OnLoad instead as I assume you want to make sure FillWSFWVars is called without knowing if it exists.