### PR TITLE
Change Send WorkshopEnterMenu Event kargs array set method

### DIFF
--- a/Scripts/Source/User/WorkshopScript.psc
+++ b/Scripts/Source/User/WorkshopScript.psc
@@ -1788,10 +1788,10 @@ Event OnWorkshopMode(bool aStart)
 	endif
 	
 	; 1.1.7 - WSFW Moving outside of aStart block
-	Var[] kargs = new Var[0]
-	kargs.Add(NONE)
-	kargs.Add(Self)
-	kargs.Add(aStart)
+	Var[] kargs = new Var[3]
+	kargs[0] = NONE
+	kargs[1] = Self
+	kargs[2] = aStart
 				
 	WorkshopParent.SendCustomEvent("WorkshopEnterMenu", kargs)		
 


### PR DESCRIPTION
According to Johnathon, calling Add is more expensive than setting the array element directly

I'm also curious if this has anything to do with errors I'm seeing from SS2 SettlementManager script where kargs[1] = none in the WorkshopParentScript.WorkshopEnterMenu event.