### PR TITLE
attempt to fix deadlock issue with GetWorkshopActors and RelinkWorkshopActors

### DIFF
--- a/Scripts/Source/User/WorkshopScript.psc
+++ b/Scripts/Source/User/WorkshopScript.psc
@@ -2997,11 +2997,13 @@ EndFunction
 
 
 Function RelinkWorkshopActors()
+	; IMPORTANT - call GetWorkshopActors() before setting "RelinkingActors" state to avoid deadlock
+	ObjectReference[] WorkshopActors = GetWorkshopActors()
+
 	GoToState("RelinkingActors")
 	; WSFW - 2.0.21 - Discovered that actors can end up in weird state where they have a sort of broken link via WorkshopItemKeyword. When this occurs, GetLinkedRef(WorkshopItemKeyword) will still show the actor as connected to the workshop, but calling RecalculateResources can count them as not being part of the settlement and they end up reducing population count and unassigning from some objects. Linking them to something else temporarily and then back seems to resolve it. 
 		
 	Keyword WorkshopItemKeyword = WorkshopFramework:WorkshopFunctions.GetWorkshopItemKeyword()
-	ObjectReference[] WorkshopActors = GetWorkshopActors()
 
 	Actor PlayerRef = Game.GetPlayer()
 	int i = WorkshopActors.Length


### PR DESCRIPTION
[Github issue link](https://github.com/kinggath/WorkshopFramework/issues/147).

Full description in the [SS2 forum thread](https://simsettlements.com/site/index.php?threads/possible-bug-deadlock-with-relinkworkshopactors-getworkshopactors.26316/).

Currently, `GetWorkshopActors` waits in the `RelinkingActors` state. The function continues to wait until the state changes to `Initialized`.

To avoid deadlock, this PR changes `RelinkWorkshopActors` to call `GetWorkshopActors` before setting the `RelinkingActors` state.