### PR TITLE
They were a little too persistent...

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Fiber_PersistenceUpdateBase.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Fiber_PersistenceUpdateBase.psc
@@ -347,7 +347,11 @@ Bool Function _ObjectHasPersistenceActorValue( ObjectReference akREFR )
     While( liIndex > 0 )
         liIndex -= 1
         
-        If( akREFR.GetBaseValue( kActorValues[ liIndex ] ) != 0.0 )
+        ;; Compare the value on the target REFR with the value on the Fiber
+        ;; The Fiber has no AVIFs so it will return the default value
+        ;; This will handle non-zero default AVIFs
+        ActorValue lkAVIF = kActorValues[ liIndex ]
+        If( akREFR.GetBaseValue( lkAVIF ) != Self.GetBaseValue( lkAVIF ) )
             Return True
         EndIf
     EndWhile

--- a/Scripts/Source/User/WorkshopFramework/PersistenceManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/PersistenceManager.psc
@@ -424,7 +424,6 @@ EndFunction
 
 ;; Mods should call this function to add their keyword that may be attached to an ObjectReference that should be persisted
 Function Add_PersistReference_Keyword( Keyword akKYWD )
-    Debug.TraceStack( "akKYWD = " + akKYWD )
     kFLST_PersistReference_Keywords.AddForm( akKYWD )
 EndFunction
 


### PR DESCRIPTION
+ fixes non-zero default AVIF values triggering persistence of everything
+ fixes save game corruption and VM crashes caused by generating too large a string in DumpPersistedRefs
+ adds more details to information reported by DumpPersistedRefs - specifically, why the reference needs persistence