### PR TITLE
Experimental code for triggering settlement enter and exit events

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -25,7 +25,22 @@ CustomEvent PlayerExitedSettlement
 ; ---------------------------------------------
 
 Int iTimerID_BuildableAreaCheck = 100 Const
-Float fTimerLength_BuildableAreaCheck = 3.0 Const
+Float fTimerLength_BuildableAreaCheck = 3.0 Const 
+
+Int iTimerID_BuildableAreaCheckForEntry = 150 Const
+Float fTimerLength_BuildableAreaCheckForEntry = 3.0 Const 
+
+Int iTimerID_BuildableAreaCheckForExit = 175 Const
+Float fTimerLength_BuildableAreaCheckForExit = 3.0 Const 
+
+Int iTimerID_WaitToSendExitEvent = 200 Const
+Float fTimerLength_WaitToSendExitEvent = 5.0
+
+Int iEntryExitStatus_Clear = 0 Const
+Int iEntryExitStatus_EnterWaitingForBuildArea = 1 Const
+Int iEntryExitStatus_In = 2 Const
+Int iEntryExitStatus_ExitWaitingForBuildArea = 3 Const
+Int iEntryExitStatus_ExitWaitingForTimer = 4 Const
 
 ; ---------------------------------------------
 ; Editor Properties
@@ -98,14 +113,22 @@ EndGroup
 ; Properties
 ; ---------------------------------------------
 
+Bool Property bUseCBRChange = false Auto
+
 Bool Property bFrameworkReady = false Auto Hidden
 Bool Property bLastSettlementUnloaded = true Auto Hidden
 
 Int Property iSaveFileMonitor Auto Hidden ; Important - only meant to be edited by our Nanny system!
 
+Bool Property bCurrentSettlementNotSetYet = true Auto Hidden ; will be changed to false the first time a player enters a settlement and kCurrentSettlement is set
+
 ; ---------------------------------------------
 ; Vars
 ; ---------------------------------------------
+
+workshopscript kCurrentSettlement = none ; will be set when the enter event is triggered and cleared when the exit event is triggered.
+workshopscript kWaitingForSettlementExit = none  ; stores the workshop of a settlement that is waiting for the exit timer to complete before PlayerExitedSettlement is sent
+workshopscript kInBuildableAreaWorkshop = none ; stores the workshop of the settlement being checked for buildable area before triggering enter or exit events
 
 ; ---------------------------------------------
 ; Events
@@ -126,108 +149,191 @@ Event OnTimer(Int aiTimerID)
 	Parent.OnTimer(aiTimerID)
 
 	if(aiTimerID == LocationChangeTimerID)
-		Location kPreviousLoc = PreviousLocation.GetLocation()
-		Location kNewLoc = LatestLocation.GetLocation()
-		Bool bEnteringWorkshopLocation = false
-		Bool bLeavingWorkshopLocation = false
-		WorkshopScript currentWorkshop = None
+		 ; if bUseCBRChange is set, alternate (experimental) code will be used to trigger enter and exit settlement events.
+		if(bUseCBRChange)
+			Location kPreviousLoc = PreviousLocation.GetLocation()
+			Location kNewLoc = LatestLocation.GetLocation()
+			WorkshopScript enteringWorkshop = None
+			WorkshopScript leavingWorkshop = None
 		
-		if(kNewLoc != None)
-			if(kNewLoc.HasKeyword(LocationTypeWorkshop))
-				bEnteringWorkshopLocation = true
-				currentWorkshop = WorkshopParent.GetWorkshopFromLocation(PlayerRef.GetCurrentLocation())
-				
-				if(F4SEManager.IsF4SERunning && Setting_AutoRepairPowerGrids.GetValueInt() == 1)
-					if(currentWorkshop.GetParentCell().IsLoaded())
-						F4SEManager.WSFWID_CheckAndFixPowerGrid(currentWorkshop, abFixAndScan = true, abResetIfFixFails = Setting_AutoResetCorruptPowerGrid.GetValueInt() as Bool)
-					else
-						RegisterForRemoteEvent(currentWorkshop, "OnCellLoad")
-					endif
-				endif
-			endif
-		endif
-
-		if(kPreviousLoc != None)
-			if(kPreviousLoc.HasKeyword(LocationTypeWorkshop))
-				bLeavingWorkshopLocation = true
-			endif
-		endif
-
-		if(bEnteringWorkshopLocation || bLeavingWorkshopLocation)
-			Var[] kArgs
-
-			; 1.0.4 - Added sanity check
-			if( ! currentWorkshop || ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
-				; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
-				currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
-
-				if(bLeavingWorkshopLocation && ! bEnteringWorkshopLocation && currentWorkshop && ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
-					currentWorkshop = None
-				else
-					if(currentWorkshop != None && currentWorkshop.myLocation != None)
-						; Player is in limbo area - it is not flagged as part of a specific location (likely just the overworld location - ie. Commonwealth) and so another LocationChange event isn't likely to fire - so instead we'll do a 5 second repeating loop to check if they returned to the location tagged part of the settlement or are out of the build area
-						StartTimer(fTimerLength_BuildableAreaCheck, iTimerID_BuildableAreaCheck)
-
-						; Update Latest Location so the next change will correctly be aware the player was previously in a settlement
-						LatestLocation.ForceLocationTo(currentWorkshop.myLocation)
-					else
-						; Player is not in limbo area
-						CancelTimer(iTimerID_BuildableAreaCheck)
-					endif
-				endif
-			endif
-
-			WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
-			Bool bCurrentWorkshopRefFound = true
-			if( ! currentWorkshop)
-				bCurrentWorkshopRefFound = false
-			endif
-
-			Bool bLastWorkshopRefFound = true
-			if( ! lastWorkshop)
-				bLastWorkshopRefFound = false
-			endif
-
-			if( ! bLastWorkshopRefFound && bCurrentWorkshopRefFound) ; This should only happen once, after which there will always be a lastWorkshop stored in the alias
-				LastWorkshopAlias.ForceRefTo(currentWorkshop)
-			endif
-
-			;Debug.Trace(">>>>>>>>>>>>>>>> bLastWorkshopRefFound: " + bLastWorkshopRefFound + ", kPreviousLoc: " + kPreviousLoc + ", kNewLoc: " + kNewLoc + ", lastWorkshop: " + lastWorkshop + ", currentWorkshop: " + currentWorkshop + ", bCurrentWorkshopRefFound: " + bCurrentWorkshopRefFound + ", bLastSettlementUnloaded: " + bLastSettlementUnloaded)
-			if(bLastWorkshopRefFound)
-				Bool bLastWorkshopLoaded = lastWorkshop.myLocation.IsLoaded()
-				kArgs = new Var[2]
-				kArgs[0] = lastWorkshop
-				kArgs[1] = bLastWorkshopLoaded ; Scripts can use this to determine if the player has actually left or is maybe just hanging out around the edge of the settlement
-
-				if(lastWorkshop != currentWorkshop && (bCurrentWorkshopRefFound || ! bLastSettlementUnloaded))
-					; Workshop changed or they are no longer in a settlement
-					if(bCurrentWorkshopRefFound)
-						; Changed settlement - update our lastWorkshop record to store the currentWorkshop
-						LastWorkshopAlias.ForceRefTo(currentWorkshop)
-					endif
-
-					if( ! bLastWorkshopLoaded)
-						; Our previous settlement is no longer loaded in memory
-						bLastSettlementUnloaded = true
-					endif
-
-					SendCustomEvent("PlayerExitedSettlement", kArgs)
-				else
-					; Player changed location but is still in same settlement - don't send event
-				endif
-			endif
-
-			if(bCurrentWorkshopRefFound && bEnteringWorkshopLocation)
-				; Workshop changed or previous settlement unloaded
-				kArgs = new Var[3]
-				kArgs[0] = currentWorkshop
-				kArgs[1] = lastWorkshop
-				kArgs[2] = bLastSettlementUnloaded ; If lastWorkshop == currentWorkshop && bLastSettlementUnloaded - it means the player traveled far enough to unload the last settlement, but never visited a new one in between
+			if(kNewLoc != None)
+				if(kNewLoc.HasKeyword(LocationTypeWorkshop))
+					enteringWorkshop = WorkshopParent.GetWorkshopFromLocation(kNewLoc)
 					
-				;Debug.MessageBox("WSFW_Main sending PlayerEnteredSettlement event")
-				SendCustomEvent("PlayerEnteredSettlement", kArgs)
+					if(F4SEManager.IsF4SERunning && Setting_AutoRepairPowerGrids.GetValueInt() == 1)
+						if(enteringWorkshop.GetParentCell().IsLoaded())
+							F4SEManager.WSFWID_CheckAndFixPowerGrid(enteringWorkshop, abFixAndScan = true, abResetIfFixFails = Setting_AutoResetCorruptPowerGrid.GetValueInt() as Bool)
+						else
+							RegisterForRemoteEvent(enteringWorkshop, "OnCellLoad")
+						endif
+					endif
+				endif
+			endif
+		
+			if(kPreviousLoc != None)
+				if(kPreviousLoc.HasKeyword(LocationTypeWorkshop))
+					leavingWorkshop = WorkshopParent.GetWorkshopFromLocation(kPreviousLoc)
+				endif
+			endif
+		
+			if(leavingWorkshop != none)
+				 ; don't trigger an exit event if the corresponding enter event hasn't triggered (unless this is the first time using the changed code)
+				if(kCurrentSettlement != none || bCurrentSettlementNotSetYet)
+					 ; Cancel any enter build area timer, as we will not be sending that entered settlement function
+					Self.CancelTimer(iTimerID_BuildableAreaCheckForEntry)
+					kInBuildableAreaWorkshop = none
+					
+					 ; check to see if the player is still in the buildable area of that workshop
+					if(PlayerRef.IsWithinBuildableArea(leavingWorkshop))
+						 ; they are, so don't call exit yet. Start a timer to check if they are out of the area.
+						kInBuildableAreaWorkshop = leavingWorkshop
+						Self.StartTimer(fTimerLength_BuildableAreaCheckForExit, iTimerID_BuildableAreaCheckForExit)
+					else
+						 ; they are not
+						if(enteringWorkshop == none)
+							 ; if the previous settlement is unloaded, run the exit event straight away (they probably fast travelled)
+							 ; otherwise, start the exit timer
+							
+							if(!leavingWorkshop.mylocation.IsLoaded())
+								SendPlayerExitedSettlementEvent(leavingWorkshop)
+							else
+								kWaitingForSettlementExit = leavingWorkshop
+								Self.StartTimer(fTimerLength_WaitToSendExitEvent, iTimerID_WaitToSendExitEvent)
+							endif
+						else
+							 ; the exit event will be run in the block below
+						endif
+					endif
+				endif
+			endif
+		
+			if(enteringWorkshop != none)
+				 ; if the player is still registered as being in another settlement, trigger that exit event
+				if(kCurrentSettlement != none && kCurrentSettlement != enteringWorkshop)
+					SendPlayerExitedSettlementEvent(kCurrentSettlement)
+				else
+					 ; cancel any build area for exit timer (this is done automatically in SendPlayerExitedSettlementEvent if that was run instead
+					Self.CancelTimer(iTimerID_BuildableAreaCheckForExit)
+					kInBuildableAreaWorkshop = none
+				endif
+				
+				 ; do not trigger the enter event if it was already triggered previously and the exit event has not been triggered
+				if(kCurrentSettlement != enteringWorkshop) 
+					 ; check to see if they are in the buildable area yet. If not, start a timer to check for it.
+					if(PlayerRef.IsWithinBuildableArea(enteringWorkshop))
+						 ; run the enter event
+						SendPlayerEnteredSettlementEvent(enteringWorkshop)
+					else
+						kInBuildableAreaWorkshop = enteringWorkshop
+						 ; start the timer
+						Self.StartTimer(fTimerLength_BuildableAreaCheckForEntry, iTimerID_BuildableAreaCheckForEntry) 
+					endif
+				endif
+			endif
+		else
+			Location kPreviousLoc = PreviousLocation.GetLocation()
+			Location kNewLoc = LatestLocation.GetLocation()
+			Bool bEnteringWorkshopLocation = false
+			Bool bLeavingWorkshopLocation = false
+			WorkshopScript currentWorkshop = None
+			
+			if(kNewLoc != None)
+				if(kNewLoc.HasKeyword(LocationTypeWorkshop))
+					bEnteringWorkshopLocation = true
+					currentWorkshop = WorkshopParent.GetWorkshopFromLocation(PlayerRef.GetCurrentLocation())
+					
+					if(F4SEManager.IsF4SERunning && Setting_AutoRepairPowerGrids.GetValueInt() == 1)
+						if(currentWorkshop.GetParentCell().IsLoaded())
+							F4SEManager.WSFWID_CheckAndFixPowerGrid(currentWorkshop, abFixAndScan = true, abResetIfFixFails = Setting_AutoResetCorruptPowerGrid.GetValueInt() as Bool)
+						else
+							RegisterForRemoteEvent(currentWorkshop, "OnCellLoad")
+						endif
+					endif
+				endif
+			endif
 
-				bLastSettlementUnloaded = false ; Since we've entered a settlement, the lastWorkshop is changing
+			if(kPreviousLoc != None)
+				if(kPreviousLoc.HasKeyword(LocationTypeWorkshop))
+					bLeavingWorkshopLocation = true
+				endif
+			endif
+
+			if(bEnteringWorkshopLocation || bLeavingWorkshopLocation)
+				Var[] kArgs
+
+				; 1.0.4 - Added sanity check
+				if( ! currentWorkshop || ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
+					; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
+					currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
+
+					if(bLeavingWorkshopLocation && ! bEnteringWorkshopLocation && currentWorkshop && ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
+						currentWorkshop = None
+					else
+						if(currentWorkshop != None && currentWorkshop.myLocation != None)
+							; Player is in limbo area - it is not flagged as part of a specific location (likely just the overworld location - ie. Commonwealth) and so another LocationChange event isn't likely to fire - so instead we'll do a 5 second repeating loop to check if they returned to the location tagged part of the settlement or are out of the build area
+							StartTimer(fTimerLength_BuildableAreaCheck, iTimerID_BuildableAreaCheck)
+
+							; Update Latest Location so the next change will correctly be aware the player was previously in a settlement
+							LatestLocation.ForceLocationTo(currentWorkshop.myLocation)
+						else
+							; Player is not in limbo area
+							CancelTimer(iTimerID_BuildableAreaCheck)
+						endif
+					endif
+				endif
+
+				WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
+				Bool bCurrentWorkshopRefFound = true
+				if( ! currentWorkshop)
+					bCurrentWorkshopRefFound = false
+				endif
+
+				Bool bLastWorkshopRefFound = true
+				if( ! lastWorkshop)
+					bLastWorkshopRefFound = false
+				endif
+
+				if( ! bLastWorkshopRefFound && bCurrentWorkshopRefFound) ; This should only happen once, after which there will always be a lastWorkshop stored in the alias
+					LastWorkshopAlias.ForceRefTo(currentWorkshop)
+				endif
+
+				;Debug.Trace(">>>>>>>>>>>>>>>> bLastWorkshopRefFound: " + bLastWorkshopRefFound + ", kPreviousLoc: " + kPreviousLoc + ", kNewLoc: " + kNewLoc + ", lastWorkshop: " + lastWorkshop + ", currentWorkshop: " + currentWorkshop + ", bCurrentWorkshopRefFound: " + bCurrentWorkshopRefFound + ", bLastSettlementUnloaded: " + bLastSettlementUnloaded)
+				if(bLastWorkshopRefFound)
+					Bool bLastWorkshopLoaded = lastWorkshop.myLocation.IsLoaded()
+					kArgs = new Var[2]
+					kArgs[0] = lastWorkshop
+					kArgs[1] = bLastWorkshopLoaded ; Scripts can use this to determine if the player has actually left or is maybe just hanging out around the edge of the settlement
+
+					if(lastWorkshop != currentWorkshop && (bCurrentWorkshopRefFound || ! bLastSettlementUnloaded))
+						; Workshop changed or they are no longer in a settlement
+						if(bCurrentWorkshopRefFound)
+							; Changed settlement - update our lastWorkshop record to store the currentWorkshop
+							LastWorkshopAlias.ForceRefTo(currentWorkshop)
+						endif
+
+						if( ! bLastWorkshopLoaded)
+							; Our previous settlement is no longer loaded in memory
+							bLastSettlementUnloaded = true
+						endif
+
+						SendCustomEvent("PlayerExitedSettlement", kArgs)
+					else
+						; Player changed location but is still in same settlement - don't send event
+					endif
+				endif
+
+				if(bCurrentWorkshopRefFound && bEnteringWorkshopLocation)
+					; Workshop changed or previous settlement unloaded
+					kArgs = new Var[3]
+					kArgs[0] = currentWorkshop
+					kArgs[1] = lastWorkshop
+					kArgs[2] = bLastSettlementUnloaded ; If lastWorkshop == currentWorkshop && bLastSettlementUnloaded - it means the player traveled far enough to unload the last settlement, but never visited a new one in between
+						
+					;Debug.MessageBox("WSFW_Main sending PlayerEnteredSettlement event")
+					SendCustomEvent("PlayerEnteredSettlement", kArgs)
+
+					bLastSettlementUnloaded = false ; Since we've entered a settlement, the lastWorkshop is changing
+				endif
 			endif
 		endif
 	elseif(aiTimerID == iTimerID_BuildableAreaCheck)
@@ -249,6 +355,32 @@ Event OnTimer(Int aiTimerID)
 
 			SendCustomEvent("PlayerExitedSettlement", kArgs)
 		endif
+	elseif(aiTimerID == iTimerID_BuildableAreaCheckForEntry)
+		 ; part of CBRGamer code change
+		 ; check to see if the player is in the Buildable area of the settlement. If they are not, repeat the timer. If they are, trigger the entrance event
+		if(PlayerRef.IsWithinBuildableArea(kInBuildableAreaWorkshop))
+			SendPlayerEnteredSettlementEvent(kInBuildableAreaWorkshop)
+		else
+			Self.StartTimer(fTimerLength_BuildableAreaCheckForEntry, iTimerID_BuildableAreaCheckForEntry)
+		endif
+	elseif(aiTimerID == iTimerID_BuildableAreaCheckForExit)
+		 ; part of CBRGamer code change
+		 ; check to see if the player is in the Buildable area of the settlement. If they are not, start the exit timer. If they are repeat this timer.
+		if(PlayerRef.IsWithinBuildableArea(kInBuildableAreaWorkshop))
+			Self.StartTimer(fTimerLength_BuildableAreaCheckForExit, iTimerID_BuildableAreaCheckForExit)
+		else
+			StartPlayerExitedSettlementWait(kInBuildableAreaWorkshop)
+		endif
+	elseif(aiTimerID == iTimerID_WaitToSendExitEvent)
+		 ; part of CBRGamer code change
+		 ; make sure the player has not gone back into the build area
+		if(!PlayerRef.IsWithinBuildableArea(kWaitingForSettlementExit)) 
+			SendPlayerExitedSettlementEvent(kWaitingForSettlementExit)
+			kWaitingForSettlementExit = none
+		else
+			 ; restart the build area timer
+			Self.StartTimer(fTimerLength_BuildableAreaCheckForExit, iTimerID_BuildableAreaCheckForExit)
+		endif
 	endif
 EndEvent
 
@@ -256,18 +388,33 @@ EndEvent
 Event OnMenuOpenCloseEvent(string asMenuName, bool abOpening)
     if(asMenuName == "WorkshopMenu")
 		if(abOpening)
-			WorkshopScript currentWorkshop = WorkshopParent.CurrentWorkshop.GetRef() as WorkshopScript
-			WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
-
-			if(lastWorkshop != currentWorkshop)
-				 ; If this happens, there is likely some serious script lag happening - but since LastWorkshopAlias is used throughout our code, we don't ever want it to be incorrect, so use this opportunity to correct it
-				 if(currentWorkshop == None || ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
-					; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
-					currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
+			if(bUseCBRChange)
+				if(kCurrentSettlement == none)
+					 ; They are clearly actually in a settlement as they have entered workshop mode. Probably in a limbo area.
+					Workshopscript currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
+					 ; make sure this is the correct workshop (it really should be - just to be sure)
+					if(PlayerRef.IsWithinBuildableArea(currentWorkshop))
+						SendPlayerEnteredSettlementEvent(currentWorkshop)
+					endif
 				endif
+				 ; we could also do a check to see if kCurrentSettlement is the build area the player is in, but this not being the case would be a rare edge case and would be corrected soon enough.
+				 ; it could only happen if they player had exited another settlement and entered this build area all in the 5 seconds it takes for the exit to trigger.
+				 ; After that, the next build mode entry, or going into the settlement location would trigger the enter event.
+			
+			else
+				WorkshopScript currentWorkshop = WorkshopParent.CurrentWorkshop.GetRef() as WorkshopScript
+				WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
 
-				if(currentWorkshop)
-					LastWorkshopAlias.ForceRefTo(currentWorkshop)
+				if(lastWorkshop != currentWorkshop)
+					 ; If this happens, there is likely some serious script lag happening - but since LastWorkshopAlias is used throughout our code, we don't ever want it to be incorrect, so use this opportunity to correct it
+					 if(currentWorkshop == None || ! PlayerRef.IsWithinBuildableArea(currentWorkshop))
+						; Check if player is in a different workshop - it can sometimes take a moment before WorkshopParent updates the CurrentWorkshop
+						currentWorkshop = WorkshopFramework:WSFW_API.GetNearestWorkshop(PlayerRef)
+					endif
+
+					if(currentWorkshop)
+						LastWorkshopAlias.ForceRefTo(currentWorkshop)
+					endif
 				endif
 			endif
 		endif
@@ -408,6 +555,63 @@ EndFunction
 ; ---------------------------------------------
 ; Functions
 ; ---------------------------------------------
+
+ ; Part of CBRGamer code change
+Function SendPlayerEnteredSettlementEvent(workshopscript akEnteringWorkshop)
+	kCurrentSettlement = akEnteringWorkshop
+	bCurrentSettlementNotSetYet = false
+	
+	 ; We can now cancel any build area check for entry
+	Self.CancelTimer(iTimerID_BuildableAreaCheckForEntry)
+	kInBuildableAreaWorkshop = none
+	
+	WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
+	bLastSettlementUnloaded = !lastWorkshop.myLocation.IsLoaded()
+	
+	Var[] kArgs = new Var[3]
+	kArgs[0] = akEnteringWorkshop
+	kArgs[1] = lastWorkshop
+	kArgs[2] = bLastSettlementUnloaded 
+	
+	; This comment is in the original : 
+	     ; If lastWorkshop == currentWorkshop && bLastSettlementUnloaded - it means the player traveled far enough to unload the last settlement, but never visited a new one in between
+	; But even in the original, bLastSettlementUnloaded was only set when you entered a settlement - so if currentWorkshop was the same is the last workshop, the last workshop must be loaded because the current one is.
+	
+	SendCustomEvent("PlayerEnteredSettlement", kArgs)
+	bLastSettlementUnloaded = false ; Since we've entered a settlement, the lastWorkshop is changing
+	LastWorkshopAlias.ForceRefTo(akEnteringWorkshop)
+EndFunction
+
+ ; Part of CBRGamer code change
+Function SendPlayerExitedSettlementEvent(workshopscript akLeavingWorkshop)
+	kCurrentSettlement = none
+	
+	 ; We can now cancel any build area check for exit and any wait timer for exit
+	Self.CancelTimer(iTimerID_BuildableAreaCheckForExit)
+	kInBuildableAreaWorkshop = none
+	Self.CancelTimer(iTimerID_WaitToSendExitEvent)
+	kWaitingForSettlementExit = none
+	
+	WorkshopScript lastWorkshop = LastWorkshopAlias.GetRef() as WorkshopScript
+	Bool bLastWorkshopLoaded = lastWorkshop.myLocation.IsLoaded()
+	
+	Var[] kArgs = new Var[2]
+	kArgs[0] = akLeavingWorkshop
+	kArgs[1] = bLastWorkshopLoaded ; Scripts can use this to determine if the player has actually left or is maybe just hanging out around the edge of the settlement
+	
+	SendCustomEvent("PlayerExitedSettlement", kArgs)
+EndFunction
+
+ ; Part of CBRGamer code change
+Function StartPlayerExitedSettlementWait(workshopscript akWaitWorkshop)
+	if(kWaitingForSettlementExit != none && akWaitWorkshop != kWaitingForSettlementExit)
+		 ; while waiting to exit one workshop, another thinks it is exiting. So exit the first, then call the exit wait on the second.
+		 ; This actually shouldn't happen, but just in case.
+		SendPlayerExitedSettlementEvent(kWaitingForSettlementExit) 
+	endif
+	kWaitingForSettlementExit = akWaitWorkshop
+	Self.StartTimer(fTimerLength_WaitToSendExitEvent, iTimerID_WaitToSendExitEvent)
+EndFunction
 
 Function ClearInWorkshopModeFlags()
 	WorkshopScript[] Workshops = WorkshopParent.Workshops


### PR DESCRIPTION
Added experimental code for triggering settlement enter and exit events more reliably.

All new code is gated behind property bUseCBRChanges, which is set to false by default.

All existing code has been kept intact. The way GitHub shows the changes can make it look like I changed the original code, but I only put it in the else of the if(bUseCBRChanges) statement.

I'm putting this in so others can test the changes if they like. The property bUseCBRChanges just needs to be set to true. Then a script that catches the enter/exit events could show a debut message when those events fire to see if it is working as intended.