### PR TITLE
Msalaba may2024

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -808,12 +808,14 @@ Function PresentIncreaseLimitsMenu(WorkshopScript akWorkshopRef)
     ; if we can't know the real value, at least assume something which shouldn't break the system
 	if(defaultCurTris <= 0.0)
 		defaultCurTris = 1.0
-		akWorkshopRef.SetValue(WorkshopCurrentTriangles, defaultCurDraws)
+		; we already checked AV on L794
+		; akWorkshopRef.SetValue(WorkshopCurrentTriangles, defaultCurDraws)
 	endif
 
     if(defaultCurDraws <= 0.0)
         defaultCurDraws = 1.0
-		akWorkshopRef.SetValue(WorkshopCurrentDraws, defaultCurDraws)
+		; we already checked AV on L789
+		; akWorkshopRef.SetValue(WorkshopCurrentDraws, defaultCurDraws)
     endif
 	
     float curMaxTris  = akWorkshopRef.getValue(WorkshopMaxTriangles)

--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -776,7 +776,7 @@ Function PresentIncreaseLimitsMenu(WorkshopScript akWorkshopRef)
 	ActorValue WorkshopCurrentTriangles = WorkshopParent.WorkshopCurrentTriangles
 
 	float defaultMaxTris  = akWorkshopRef.MaxTriangles
-    float defaultMaxDraws = akWorkshopRef.MaxDraws
+	float defaultMaxDraws = akWorkshopRef.MaxDraws
 
 	float defaultCurTris = akWorkshopRef.CurrentTriangles
 	float defaultCurDraws = akWorkshopRef.CurrentDraws
@@ -787,11 +787,13 @@ Function PresentIncreaseLimitsMenu(WorkshopScript akWorkshopRef)
 	; 2.4.0 - add current value check no matter if player adjusts or not.
 	; something allows WorkshopCurrentDraws to be set to a negative value.
 	if ( currentDraws <= 0.0 )
-		akWorkshopRef.SetValue(WorkshopCurrentDraws, 1.0)
+		currentDraws = 1.0
+		akWorkshopRef.SetValue(WorkshopCurrentDraws, currentDraws)
 	endif
 	
 	if ( currentTris <= 0.0 )
-		akWorkshopRef.SetValue(WorkshopCurrentTriangles, 1.0)
+		currentTris = 1.0
+		akWorkshopRef.SetValue(WorkshopCurrentTriangles, currentTris)
 	endif
 	
 	; prevent division by zero: assume Sanctuary values

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
@@ -450,22 +450,24 @@ Function RunCode()
 				endWhile
 			endif
 			
-			; switch SetValue to Mod in an attempt to prevent race conditions setting these to a negative value.
+			; 2.4.0 - add check to prevent setting these to a negative value.
 			if(bApplyDrawCount)
 				Float fItemDraws = kResult.GetValue(WorkshopCurrentDraws)
-				Float fCurrentDraws = kWorkshopRef.GetValue(WorkshopCurrentDraws)
-					
-				if(fItemDraws > 0.0 && fCurrentDraws + fItemDraws > 0.0)
-					kWorkshopRef.Mod(WorkshopCurrentDraws, (fItemDraws))
+				if(fItemDraws > 0.0)
+					Float fCurrentDraws = kWorkshopRef.GetValue(WorkshopCurrentDraws) + fItemDraws
+					if (fCurrentDraws > 0.0)
+						kWorkshopRef.SetValue(WorkshopCurrentDraws, (fCurrentDraws)
+					endif
 				endif
 			endif
 			
 			if(bApplyTriCount)
 				Float fItemTris = kResult.GetValue(WorkshopCurrentTriangles)
-				Float fCurrentTris = kWorkshopRef.GetValue(WorkshopCurrentTriangles)
-					
-				if(fItemTris > 0.0 && fCurrentTris + fItemTris > 0.0)
-					kWorkshopRef.Mod(WorkshopCurrentTriangles, (fItemTris))
+				if(fItemTris > 0.0)
+					Float fCurrentTris = kWorkshopRef.GetValue(WorkshopCurrentTriangles) + fItemTris
+					if (fCurrentTris > 0.0)
+						kWorkshopRef.SetValue(WorkshopCurrentTriangles, (fCurrentTris))
+					endif
 				endif
 			endif
 			

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
@@ -453,19 +453,19 @@ Function RunCode()
 			; switch SetValue to Mod in an attempt to prevent race conditions setting these to a negative value.
 			if(bApplyDrawCount)
 				Float fItemDraws = kResult.GetValue(WorkshopCurrentDraws)
-				
-				if(fItemDraws > 0)
-					Float fCurrentDraws = kWorkshopRef.GetValue(WorkshopCurrentDraws)
-					kWorkshopRef.Mod(WorkshopCurrentDraws, (fCurrentDraws + fItemDraws))
+				Float fCurrentDraws = kWorkshopRef.GetValue(WorkshopCurrentDraws)
+					
+				if(fItemDraws > 0.0 && fCurrentDraws + fItemDraws > 0.0)
+					kWorkshopRef.Mod(WorkshopCurrentDraws, (fItemDraws))
 				endif
 			endif
 			
 			if(bApplyTriCount)
 				Float fItemTris = kResult.GetValue(WorkshopCurrentTriangles)
-				
-				if(fItemTris > 0)
-					Float fCurrentTris = kWorkshopRef.GetValue(WorkshopCurrentTriangles)
-					kWorkshopRef.Mod(WorkshopCurrentTriangles, (fCurrentTris + fItemTris))
+				Float fCurrentTris = kWorkshopRef.GetValue(WorkshopCurrentTriangles)
+					
+				if(fItemTris > 0.0 && fCurrentTris + fItemTris > 0.0)
+					kWorkshopRef.Mod(WorkshopCurrentTriangles, (fItemTris))
 				endif
 			endif
 			

--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/Thread_PlaceObject.psc
@@ -450,21 +450,22 @@ Function RunCode()
 				endWhile
 			endif
 			
+			; switch SetValue to Mod in an attempt to prevent race conditions setting these to a negative value.
 			if(bApplyDrawCount)
-				Float fCurrentDraws = kWorkshopRef.GetValue(WorkshopCurrentDraws)
 				Float fItemDraws = kResult.GetValue(WorkshopCurrentDraws)
 				
 				if(fItemDraws > 0)
-					kWorkshopRef.SetValue(WorkshopCurrentDraws, (fCurrentDraws + fItemDraws))
+					Float fCurrentDraws = kWorkshopRef.GetValue(WorkshopCurrentDraws)
+					kWorkshopRef.Mod(WorkshopCurrentDraws, (fCurrentDraws + fItemDraws))
 				endif
 			endif
 			
 			if(bApplyTriCount)
-				Float fCurrentTris = kWorkshopRef.GetValue(WorkshopCurrentTriangles)
 				Float fItemTris = kResult.GetValue(WorkshopCurrentTriangles)
 				
 				if(fItemTris > 0)
-					kWorkshopRef.SetValue(WorkshopCurrentTriangles, (fCurrentTris + fItemTris))
+					Float fCurrentTris = kWorkshopRef.GetValue(WorkshopCurrentTriangles)
+					kWorkshopRef.Mod(WorkshopCurrentTriangles, (fCurrentTris + fItemTris))
 				endif
 			endif
 			


### PR DESCRIPTION
Collection of bug fix requests for the next patch.

First is an attempt to prevent AV WorkshopCurrentDraws begin set to -1 on a workshop.
I have not figured out what causes this, be by being set to -1, the workshop acts as if the build limit it maxed.
I do know it is not a mod conflict. It may be SS2 plot code, I have submitted a separate PR for that.
My best guess is either script lag or a race issue. I added a check for negative results and switched SetValue to Mod.