### PR TITLE
Add none check to InvisibleWorkshopObject.DeleteControlledRef

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
+++ b/Scripts/Source/User/WorkshopFramework/ObjectRefs/InvisibleWorkshopObject.psc
@@ -280,9 +280,11 @@ EndFunction
 
 Function DeleteControlledRef()
 	Self.SetLinkedRef(None, WorkshopStackedItemParentKeyword)
-	kControlledRef.SetLinkedRef(None, WorkshopStackedItemParentKeyword)
-	kControlledRef.SetLinkedRef(None, WorkshopItemKeyword)
-	kControlledRef.Disable(false)
-	kControlledRef.Delete()
-	kControlledRef = None
+	if ( kControlledRef != none )
+		kControlledRef.SetLinkedRef(None, WorkshopStackedItemParentKeyword)
+		kControlledRef.SetLinkedRef(None, WorkshopItemKeyword)
+		kControlledRef.Disable(false)
+		kControlledRef.Delete()
+		kControlledRef = None
+	endif
 EndFunction


### PR DESCRIPTION
add test for kControlledRef before trying to call functions on it as it can be none.

I got the following from using my Raze my Settlement - F4SE mod to scrap a settlement with a city plan applied for giggles. I has thousands of lines similar to the following in papyrus.log.
```
[05/31/2025 - 03:47:35PM] error: Cannot call SetLinkedRef() on a None object, aborting function call stack:
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.DeleteControlledRef() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 283
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Cleanup() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 278
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Delete() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 272
	
	<truncated stack>
[05/31/2025 - 03:47:35PM] error: Cannot call SetLinkedRef() on a None object, aborting function call stack:
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.DeleteControlledRef() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 284
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Cleanup() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 278
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Delete() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 272
	
	<truncated stack>
[05/31/2025 - 03:47:35PM] error: Cannot call Disable() on a None object, aborting function call stack:
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.DeleteControlledRef() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 285
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Cleanup() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 278
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Delete() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 272
	
	<truncated stack>
[05/31/2025 - 03:47:35PM] error: Cannot call Delete() on a None object, aborting function call stack:
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.DeleteControlledRef() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 286
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Cleanup() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 278
	[ (FF0045F7)].workshopframework:objectrefs:invisibleworkshopobject.Delete() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4 - Backup 042524\Data\Scripts\Source\User\WorkshopFramework\ObjectRefs\InvisibleWorkshopObject.psc" Line 272
	
	<truncated stack>
```
It may be something in WRK that can be place but is misconfigured. I figure the easiest solution is to ignore these calls if the var is none.