### PR TITLE
new option to disable, new settler flag when settler override is used.

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/NPCManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/NPCManager.psc
@@ -134,6 +134,10 @@ EndGroup
 ; 1.0.1 - Temporary fix until we can alter the framework to handle what this mod is doing
 Bool Property bOverrideInjectedSettlers = false Auto Hidden
 
+; Option to turn off new settler flag when SettlerOverride
+Bool Property bNewSettlerFlag = true Auto
+; Bool to switch if bNewSettlerFlag is set to False
+Bool Property bNewSettlerDisabled = False Auto
 
 ; ---------------------------------------------
 ; Properties
@@ -502,6 +506,9 @@ ActorBase Function GetSettlerForm(WorkshopScript akWorkshopRef = None)
 		FactionControl thisFactionControl = akWorkshopRef.FactionControlData
 		if(thisFactionControl != None && thisFactionControl.SettlerOverride != None)
 			thisActorBase = thisFactionControl.SettlerOverride
+			if (bNewSettlerFlag == False)
+				bNewSettlerDisabled = True
+			endif
 		endif
 	endif
 	
@@ -592,6 +599,10 @@ WorkshopNPCScript Function CreateWorkshopNPC(ActorBase aActorForm, WorkshopScrip
 		endif
 
 		WorkshopNewSettlerAlias.ForceRefTo(asWorkshopNPC)
+
+		if bNewSettlerDisabled == True
+		WorkshopFramework:WorkshopFunctions.SetNewSettler(asWorkshopNPC, False)
+		endif
 		
 		; 1.1.1 - Add event when a new settler is spawned and added to workshop
 		Var[] kArgs = new Var[2]		


### PR DESCRIPTION
It doesn't make sense for faction settlers (i.e. Gunners, Forged etc.) to gratuitously thank the player and offer a hand on arrival nor  use most of the WorkshopDialogueFaction lines. However, when the WorkshopDialogueFaction is removed the NewSettler flag still tries to run and results in the NPC Force Greet automatically opening the trade menu.

This also doesn't allow the NewSettler flag to be switched back to False so the NPC continues to do this until a new NPC takes their place.

- Added bool bNewSettlerFlag under GetSettlerForm as option for mod author to switch to False if they don't want their SettlerOverride (WorkshopControlManager) actor base to use NewSettler flag.
- Added bool bNewSettlerDisabled under CreateWorkshopNPC which will be set to TRUE ONLY if bNewSettlerFlag has been switched to FALSE.
- This allows vanilla settlers or settlers using CustomWorkshopNPC to continue using the NewSettler flag while any NPC's using SettlerOverride do not.
- It is therefore safe to remove WorkshopDialogueFaction from any ActorBase using the SettlerOverride.

How to test:
- Set up a FactionControl struct and assign an ActorBase to SettlerOverride
- Call CaptureSettlement (WorkshopControlManager)
- Call CreateSettler.

I am currently contributing in the development of Faction Workshop Manager by Vneckjumper which this would directly benefit.

This would also be beneficial to anyone wanting to remove WorkshopDialogueFaction from their settlers without affecting vanilla settlers at the same time.

If there is a better way this could be achieved please let us know!
